### PR TITLE
Fix Import of Prover Middlewares in Test

### DIFF
--- a/arbitrator/polyglot/src/test.rs
+++ b/arbitrator/polyglot/src/test.rs
@@ -12,7 +12,7 @@ use brotli2::read::{BrotliDecoder, BrotliEncoder};
 use eyre::{bail, Result};
 use prover::{
     machine::MachineStatus,
-    middlewares::{
+    programs::{
         depth::DepthCheckedMachine,
         meter::{MachineMeter, MeteredMachine},
         GlobalMod, PolyglotConfig,


### PR DESCRIPTION
Middlewares was changed to `programs`, preventing the test.rs from compiling during a cargo test call