### PR TITLE
Ensure Safe Gas Price Setting and Test EVM Gas Purchasing

### DIFF
--- a/arbitrator/polyglot/src/machine.rs
+++ b/arbitrator/polyglot/src/machine.rs
@@ -104,6 +104,7 @@ impl Deref for WasmEnvArc {
 
 impl WasmEnvArc {
     pub fn new(args: &[u8], gas_price: u64) -> Self {
+        assert!(gas_price > 0, "gas price must be > 0");
         let mut env = WasmEnv::default();
         env.args = args.to_owned();
         env.gas_price = gas_price;


### PR DESCRIPTION
Upon reading the code, noticed a few places where we divide by the gas price of the wasm environment, which a caller could mistakenly set to 0 and lead to panics at runtime. This PR also adds a regression test and further tests for checking if we can buy EVM gas correctly for an instance's environment