### PR TITLE
new opcode implementations

### DIFF
--- a/arbitrator/prover/src/host.rs
+++ b/arbitrator/prover/src/host.rs
@@ -91,7 +91,7 @@ pub fn get_host_impl(module: &str, name: &str) -> eyre::Result<Function> {
         }
         ("env", "wavm_get_caller_module") => {
             ty = FunctionType::new(vec![], vec![I32]);
-            opcode!(CurrentModule);
+            opcode!(CallerModule);
         }
         ("env", "wavm_link_program") => {
             ty = FunctionType::new(vec![I32], vec![I32]);

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -1682,7 +1682,7 @@ impl Machine {
                         caller_module_internals,
                     });
                 }
-                Opcode::CurrentModule => {
+                Opcode::CallerModule => {
                     let frame = self.frame_stack.last().unwrap();
                     self.value_stack.push(frame.caller_module.into());
                 }

--- a/arbitrator/prover/src/wavm.rs
+++ b/arbitrator/prover/src/wavm.rs
@@ -138,8 +138,8 @@ pub enum Opcode {
     MoveFromInternalToStack,
     /// Duplicate the top value on the stack
     Dup,
-    /// Reads the stack frame
-    CurrentModule,
+    /// Reads the stack frame for the calling module, which may have been forwarded
+    CallerModule,
     /// Call a function in a different module
     CrossModuleCall,
     /// Call a function in a different module, acting as the caller's module
@@ -266,18 +266,18 @@ impl Opcode {
             Opcode::MoveFromInternalToStack => 0x8006,
             Opcode::Dup => 0x8008,
             Opcode::CrossModuleCall => 0x8009,
-            Opcode::CrossModuleForward => 0x800D,
-            Opcode::CrossModuleDynamicCall => 0x800E,
+            Opcode::CrossModuleForward => 0x800C,
+            Opcode::CrossModuleDynamicCall => 0x800D,
             Opcode::CallerModuleInternalCall => 0x800A,
-            Opcode::CurrentModule => 0x800B,
             Opcode::GetGlobalStateBytes32 => 0x8010,
             Opcode::SetGlobalStateBytes32 => 0x8011,
             Opcode::GetGlobalStateU64 => 0x8012,
             Opcode::SetGlobalStateU64 => 0x8013,
             Opcode::ReadPreImage => 0x8020,
             Opcode::ReadInboxMessage => 0x8021,
-            Opcode::LinkModule => 0x800C,
             Opcode::HaltAndSetFinished => 0x8022,
+            Opcode::CallerModule => 0x8023,
+            Opcode::LinkModule => 0x8024,
         }
     }
 

--- a/contracts/src/osp/OneStepProofEntry.sol
+++ b/contracts/src/osp/OneStepProofEntry.sol
@@ -113,7 +113,7 @@ contract OneStepProofEntry is IOneStepProofEntry {
         } else if (
             (opcode >= Instructions.GET_GLOBAL_STATE_BYTES32 &&
                 opcode <= Instructions.SET_GLOBAL_STATE_U64) ||
-            (opcode >= Instructions.READ_PRE_IMAGE && opcode <= Instructions.HALT_AND_SET_FINISHED)
+            (opcode >= Instructions.READ_PRE_IMAGE && opcode <= Instructions.LINK_MODULE)
         ) {
             prover = proverHostIo;
         } else {

--- a/contracts/src/osp/OneStepProver0.sol
+++ b/contracts/src/osp/OneStepProver0.sol
@@ -157,6 +157,53 @@ contract OneStepProver0 is IOneStepProver {
         mach.functionPc = 0;
     }
 
+    function executeCrossModuleForward(
+        Machine memory mach,
+        Module memory mod,
+        Instruction calldata inst,
+        bytes calldata
+    ) internal pure {
+        // Push the return pc to the stack
+        mach.valueStack.push(createReturnValue(mach));
+
+        // Push caller's caller module info to the stack
+        StackFrame memory frame = mach.frameStack.peek();
+        mach.valueStack.push(ValueLib.newI32(frame.callerModule));
+        mach.valueStack.push(ValueLib.newI32(frame.callerModuleInternals));
+
+        // Jump to the target
+        uint32 func = uint32(inst.argumentData);
+        uint32 module = uint32(inst.argumentData >> 32);
+        require(inst.argumentData >> 64 == 0, "BAD_CROSS_MODULE_CALL_DATA");
+        mach.moduleIdx = module;
+        mach.functionIdx = func;
+        mach.functionPc = 0;
+    }
+
+    function executeCrossModuleDynamicCall(
+        Machine memory mach,
+        Module memory mod,
+        Instruction calldata inst,
+        bytes calldata
+    ) internal pure {
+        // Get the target from the stack
+        uint32 func = mach.valueStack.pop().assumeI32();
+        uint32 module = mach.valueStack.pop().assumeI32();
+
+        // Push the return pc to the stack
+        mach.valueStack.push(createReturnValue(mach));
+
+        // Push caller module info to the stack
+        mach.valueStack.push(ValueLib.newI32(mach.moduleIdx));
+        mach.valueStack.push(ValueLib.newI32(mod.internalsOffset));
+
+        // Jump to the target
+        require(inst.argumentData >> 64 == 0, "BAD_CROSS_MODULE_CALL_DATA");
+        mach.moduleIdx = module;
+        mach.functionIdx = func;
+        mach.functionPc = 0;
+    }
+
     function executeCallerModuleInternalCall(
         Machine memory mach,
         Module memory mod,
@@ -454,6 +501,10 @@ contract OneStepProver0 is IOneStepProver {
             impl = executeCall;
         } else if (opcode == Instructions.CROSS_MODULE_CALL) {
             impl = executeCrossModuleCall;
+        } else if (opcode == Instructions.CROSS_MODULE_FORWARD) {
+            impl = executeCrossModuleForward;
+        } else if (opcode == Instructions.CROSS_MODULE_DYNAMIC_CALL) {
+            impl = executeCrossModuleDynamicCall;
         } else if (opcode == Instructions.CALLER_MODULE_INTERNAL_CALL) {
             impl = executeCallerModuleInternalCall;
         } else if (opcode == Instructions.CALL_INDIRECT) {

--- a/contracts/src/osp/OneStepProverHostIo.sol
+++ b/contracts/src/osp/OneStepProverHostIo.sol
@@ -17,6 +17,7 @@ contract OneStepProverHostIo is IOneStepProver {
     using ModuleMemoryLib for ModuleMemory;
     using ValueLib for Value;
     using ValueStackLib for ValueStack;
+    using StackFrameLib for StackFrameWindow;
 
     uint256 private constant LEAF_SIZE = 32;
     uint256 private constant INBOX_NUM = 2;
@@ -286,6 +287,29 @@ contract OneStepProverHostIo is IOneStepProver {
         mach.status = MachineStatus.FINISHED;
     }
 
+    function executeCallerModule(
+        ExecutionContext calldata,
+        Machine memory mach,
+        Module memory,
+        Instruction calldata,
+        bytes calldata
+    ) internal pure {
+        StackFrame memory frame = mach.frameStack.peek();
+        mach.valueStack.push(ValueLib.newI32(frame.callerModule));
+    }
+
+    function executeLinkModule(
+        ExecutionContext calldata,
+        Machine memory mach,
+        Module memory,
+        Instruction calldata,
+        bytes calldata proof
+    ) internal pure {
+        /*Value memory pointer = mach.valueStack.pop();
+        Value memory module = // get memory
+        mach.*/
+    }
+
     function executeGlobalStateAccess(
         ExecutionContext calldata,
         Machine memory mach,
@@ -347,6 +371,10 @@ contract OneStepProverHostIo is IOneStepProver {
             impl = executeReadInboxMessage;
         } else if (opcode == Instructions.HALT_AND_SET_FINISHED) {
             impl = executeHaltAndSetFinished;
+        } else if (opcode == Instructions.CALLER_MODULE) {
+            impl = executeCallerModule;
+        } else if (opcode == Instructions.LINK_MODULE) {
+            impl = executeLinkModule;
         } else {
             revert("INVALID_MEMORY_OPCODE");
         }

--- a/contracts/src/state/Instructions.sol
+++ b/contracts/src/state/Instructions.sol
@@ -134,6 +134,8 @@ library Instructions {
     uint16 internal constant DUP = 0x8008;
     uint16 internal constant CROSS_MODULE_CALL = 0x8009;
     uint16 internal constant CALLER_MODULE_INTERNAL_CALL = 0x800A;
+    uint16 internal constant CROSS_MODULE_FORWARD = 0x800B;
+    uint16 internal constant CROSS_MODULE_DYNAMIC_CALL = 0x800C;
 
     uint16 internal constant GET_GLOBAL_STATE_BYTES32 = 0x8010;
     uint16 internal constant SET_GLOBAL_STATE_BYTES32 = 0x8011;
@@ -143,6 +145,8 @@ library Instructions {
     uint16 internal constant READ_PRE_IMAGE = 0x8020;
     uint16 internal constant READ_INBOX_MESSAGE = 0x8021;
     uint16 internal constant HALT_AND_SET_FINISHED = 0x8022;
+    uint16 internal constant CALLER_MODULE = 0x8023;
+    uint16 internal constant LINK_MODULE = 0x8024;
 
     uint256 internal constant INBOX_INDEX_SEQUENCER = 0;
     uint256 internal constant INBOX_INDEX_DELAYED = 1;


### PR DESCRIPTION
Adds solidity support for the 4 new wasm opcodes
- `CurrentModule` gets the current module (needed to introspect the program's environment in poly_host)
- `CrossModuleForward` calls a function in a different module, acting as the caller's module
- `CrossModuleDynamicCall` same as CrossModuleCall but the destination is determined at runtime via the stack
- `LinkModule` dynamically adds a module to the machine, allowing execution to jump into user code