### PR TITLE
operator counter edits & tests

### DIFF
--- a/arbitrator/prover/src/binary.rs
+++ b/arbitrator/prover/src/binary.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     programs::{
-        config::StylusConfig, depth::DepthChecker, heap::HeapBound, meter::Meter,
+        config::StylusConfig, counter::Counter, depth::DepthChecker, heap::HeapBound, meter::Meter,
         start::StartMover, FuncMiddleware, Middleware, StylusGlobals,
     },
     value::{ArbValueType, FunctionType, IntegerValType, Value},
@@ -522,6 +522,11 @@ impl<'a> WasmBinary<'a> {
         bound.update_module(self)?;
         start.update_module(self)?;
 
+        let count = config.debug.as_ref().map(|_| Counter::new());
+        if let Some(count) = &count {
+            count.update_module(self)?;
+        }
+
         for (index, code) in self.codes.iter_mut().enumerate() {
             let index = LocalFunctionIndex::from_u32(index as u32);
             let locals: Vec<Type> = code.locals.iter().map(|x| x.value.into()).collect();
@@ -550,6 +555,11 @@ impl<'a> WasmBinary<'a> {
             apply!(depth);
             apply!(bound);
             apply!(start);
+
+            if let Some(count) = &count {
+                apply!(*count);
+            }
+
             code.expr = build;
         }
 

--- a/arbitrator/prover/src/programs/meter.rs
+++ b/arbitrator/prover/src/programs/meter.rs
@@ -3,7 +3,7 @@
 
 use super::{FuncMiddleware, Middleware, ModuleMod};
 use crate::Machine;
-use arbutil::operator::operator_at_end_of_basic_block;
+use arbutil::operator::OperatorInfo;
 use eyre::Result;
 use parking_lot::Mutex;
 use std::fmt::Debug;
@@ -101,7 +101,7 @@ impl<'a, F: OpcodePricer> FuncMiddleware<'a> for FuncMeter<'a, F> {
     {
         use Operator::*;
 
-        let end = operator_at_end_of_basic_block(&op);
+        let end = op.ends_basic_block();
 
         let mut cost = self.block_cost.saturating_add((self.costs)(&op));
         self.block_cost = cost;

--- a/arbitrator/stylus/tests/clz.wat
+++ b/arbitrator/stylus/tests/clz.wat
@@ -2,9 +2,10 @@
 ;; For license information, see https://github.com/nitro/blob/master/LICENSE
 
 (module
+    (global $global (mut i64) (i64.const 32))
     (func $start
-        i32.const 1
-        i32.clz
+        global.get $global
+        i64.clz
         drop
         )
     (start $start))


### PR DESCRIPTION
Suggested edits to
- #26 

In addition to some basic edits, this PR
- expands test coverage to C and Rust programs
- adds the counting middleware to `Machine` and tests its equivalence
- solves a footgun around data aliasing when cloning stylus configs
