### PR TITLE
Partial Return Data PR edits

### DIFF
--- a/arbitrator/langs/rust/src/contract.rs
+++ b/arbitrator/langs/rust/src/contract.rs
@@ -1,7 +1,11 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
-use crate::{address as addr, hostio, Bytes20, Bytes32};
+use crate::{
+    address as addr,
+    hostio::{self, RETURN_DATA_SIZE},
+    Bytes20, Bytes32,
+};
 
 #[derive(Clone, Default)]
 #[must_use]
@@ -117,10 +121,10 @@ impl Call {
         };
 
         unsafe {
-            hostio::CACHED_RETURN_DATA_SIZE.set(outs_len as u32);
+            hostio::RETURN_DATA_SIZE.set(outs_len);
         }
 
-        let outs = partial_return_data_impl(self.offset, self.size, outs_len);
+        let outs = read_return_data(self.offset, self.size);
         match status {
             0 => Ok(outs),
             _ => Err(outs),
@@ -128,39 +132,17 @@ impl Call {
     }
 }
 
-fn partial_return_data_impl(offset: usize, size: Option<usize>, full_size: usize) -> Vec<u8> {
-    let mut offset = offset;
-    if offset > full_size {
-        offset = full_size;
-    }
-    let remaining_size = full_size - offset;
-    let mut allocated_len = size.unwrap_or(remaining_size);
-    if allocated_len > remaining_size {
-        allocated_len = remaining_size;
-    }
-    let mut data = Vec::with_capacity(allocated_len);
-    if allocated_len > 0 {
-        unsafe {
-            let written_size = hostio::read_return_data(data.as_mut_ptr(), offset, allocated_len);
-            assert!(written_size <= allocated_len);
-            data.set_len(written_size);
-        }
-    };
-
-    data
-}
-
 pub fn create(code: &[u8], endowment: Bytes32, salt: Option<Bytes32>) -> Result<Bytes20, Vec<u8>> {
-    let mut contract = [0; 20];
+    let mut contract = Bytes20::default();
     let mut revert_data_len = 0;
-    let contract = unsafe {
+    unsafe {
         if let Some(salt) = salt {
             hostio::create2(
                 code.as_ptr(),
                 code.len(),
                 endowment.ptr(),
                 salt.ptr(),
-                contract.as_mut_ptr(),
+                contract.ptr_mut(),
                 &mut revert_data_len as *mut _,
             );
         } else {
@@ -172,15 +154,10 @@ pub fn create(code: &[u8], endowment: Bytes32, salt: Option<Bytes32>) -> Result<
                 &mut revert_data_len as *mut _,
             );
         }
-        Bytes20(contract)
-    };
+        RETURN_DATA_SIZE.set(revert_data_len);
+    }
     if contract.is_zero() {
-        unsafe {
-            let mut revert_data = Vec::with_capacity(revert_data_len);
-            let used_len = hostio::read_return_data(revert_data.as_mut_ptr(), 0, revert_data_len);
-            revert_data.set_len(used_len);
-            return Err(revert_data);
-        }
+        return Err(read_return_data(0, None));
     }
     Ok(contract)
 }
@@ -194,10 +171,17 @@ pub fn address() -> Bytes20 {
 pub fn balance() -> Bytes32 {
     addr::balance(address())
 }
-pub fn partial_return_data(offset: usize, size: usize) -> Vec<u8> {
-    partial_return_data_impl(offset, Some(size), return_data_len())
-}
 
-fn return_data_len() -> usize {
-    unsafe { hostio::CACHED_RETURN_DATA_SIZE.get() as usize }
+pub fn read_return_data(offset: usize, size: Option<usize>) -> Vec<u8> {
+    let size = unsafe { size.unwrap_or_else(|| RETURN_DATA_SIZE.get() - offset) };
+
+    let mut data = Vec::with_capacity(size);
+    if size > 0 {
+        unsafe {
+            let bytes_written = hostio::read_return_data(data.as_mut_ptr(), offset, size);
+            debug_assert!(bytes_written <= size);
+            data.set_len(bytes_written);
+        }
+    };
+    data
 }

--- a/arbitrator/langs/rust/src/hostio.rs
+++ b/arbitrator/langs/rust/src/hostio.rs
@@ -229,7 +229,7 @@ extern "C" {
     pub(crate) fn read_args(dest: *mut u8);
 
     /// Copies the bytes of the last EVM call or deployment return result. Reverts if out of
-    /// bounds. Te semantics are equivalent to that of the EVM's [`RETURN_DATA_COPY`] opcode.
+    /// bounds. The semantics are equivalent to that of the EVM's [`RETURN_DATA_COPY`] opcode.
     ///
     /// [`RETURN_DATA_COPY`]: <https://www.evm.codes/#3e>
     pub(crate) fn read_return_data(dest: *mut u8, offset: usize, size: usize) -> usize;
@@ -244,7 +244,7 @@ extern "C" {
     /// [`RETURN_DATA_SIZE`] opcode.
     ///
     /// [`RETURN_DATA_SIZE`]: <https://www.evm.codes/#3d>
-    pub(crate) fn return_data_size() -> u32;
+    pub(crate) fn return_data_size() -> usize;
 
     /// Static calls the contract at the given address, with the option to limit the amount of gas
     /// supplied. The return status indicates whether the call succeeded, and is nonzero on
@@ -310,28 +310,19 @@ extern "C" {
     pub(crate) fn log_txt(text: *const u8, len: usize);
 }
 
-pub(crate) static mut CACHED_RETURN_DATA_SIZE: CachedResult<u32, fn() -> u32> = CachedResult {
-    value: None,
-    callback: || unsafe { return_data_size() },
-};
+/// Caches the length of the most recent EVM return data
+pub(crate) static mut RETURN_DATA_SIZE: CachedOption<usize> = CachedOption::new(return_data_size);
 
-pub(crate) struct CachedResult<T: Copy, CB: Fn() -> T> {
-    pub(crate) value: Option<T>,
-    pub(crate) callback: CB,
+/// Caches a value to avoid paying for hostio invocations.
+pub(crate) struct CachedOption<T: Copy> {
+    value: Option<T>,
+    loader: unsafe extern "C" fn() -> T,
 }
 
-impl<T: Copy, CB: Fn() -> T> CachedResult<T, CB> {
-    #[allow(dead_code)]
-    pub(crate) fn new(callback: CB) -> Self {
-        Self {
-            value: None,
-            callback,
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn clear(&mut self) {
-        self.value = None;
+impl<T: Copy> CachedOption<T> {
+    const fn new(loader: unsafe extern "C" fn() -> T) -> Self {
+        let value = None;
+        Self { value, loader }
     }
 
     pub(crate) fn set(&mut self, value: T) {
@@ -343,27 +334,8 @@ impl<T: Copy, CB: Fn() -> T> CachedResult<T, CB> {
             return *value;
         }
 
-        let value = (self.callback)();
+        let value = unsafe { (self.loader)() };
         self.value = Some(value);
         value
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_cached_result() {
-        let mut cache: CachedResult<u32, fn() -> u32> = CachedResult {
-            value: None,
-            callback: || 41,
-        };
-
-        assert_eq!(cache.get(), 41);
-        cache.set(42);
-        assert_eq!(cache.get(), 42);
-        cache.clear();
-        assert_eq!(cache.get(), 41);
     }
 }

--- a/arbitrator/langs/rust/src/util.rs
+++ b/arbitrator/langs/rust/src/util.rs
@@ -17,6 +17,10 @@ impl Bytes20 {
         self.0.as_ptr()
     }
 
+    pub fn ptr_mut(&mut self) -> *mut u8 {
+        self.0.as_mut_ptr()
+    }
+
     pub fn from_slice(data: &[u8]) -> Result<Self, TryFromSliceError> {
         Ok(Self(data.try_into()?))
     }


### PR DESCRIPTION
This PR edits the following
- #81 

Important changes include
- Simplify types and tests
- Fix a contract deployment bug

Still needed
- Reading partial return data should charge before clone