### PR TITLE
Jit call contract threading

### DIFF
--- a/arbitrator/jit/src/machine.rs
+++ b/arbitrator/jit/src/machine.rs
@@ -217,6 +217,8 @@ pub struct WasmEnv {
     pub process: ProcessEnv,
     /// The exported funcs callable in hostio
     pub exports: WasmEnvFuncs,
+    /// sub-process handling stylus calls
+    pub stylus_thread_handler: user::StylusThreadHandler,
 }
 
 impl WasmEnv {

--- a/arbitrator/jit/src/user/evm_api.rs
+++ b/arbitrator/jit/src/user/evm_api.rs
@@ -7,11 +7,12 @@ use crate::{
     gostack::GoStack,
     machine::WasmEnvMut,
     syscall::{DynamicObject, GoValue, JsValue, STYLUS_ID},
+    user::{DownMsg, StylusThreadHandler, UpMsg, StylusLaunchParams},
 };
 use arbutil::{
     evm::{
         js::{ApiValue, JsCallIntoGo, JsEvmApi},
-        user::{UserOutcome, UserOutcomeKind},
+        user::UserOutcome,
         EvmData,
     },
     Color,
@@ -19,33 +20,142 @@ use arbutil::{
 use eyre::{bail, Result};
 use prover::programs::prelude::*;
 use std::{
-    sync::mpsc::{self, SyncSender},
+    sync::{
+        mpsc::{self, Receiver, SyncSender},
+        Arc, Mutex,
+    },
     thread,
+    time::Duration,
 };
 use stylus::{native::NativeInstance, run::RunProgram};
 
-struct ApiCaller {
-    parent: SyncSender<EvmMsg>,
+struct StylusThreadData {
+    up: SyncSender<UpMsg>,
+    down: Mutex<Receiver<DownMsg>>,
 }
 
-enum EvmMsg {
-    Call(u32, Vec<ApiValue>, SyncSender<Vec<ApiValue>>),
-    Panic(String),
-    Done,
+#[derive(Clone)]
+struct StylusThread {
+    data: Arc<StylusThreadData>,
 }
 
-impl ApiCaller {
-    fn new(parent: SyncSender<EvmMsg>) -> Self {
-        Self { parent }
+impl StylusThread {
+    fn new(
+        up: SyncSender<UpMsg>,
+        down: Receiver<DownMsg>,
+    ) -> Self {
+        Self {
+            data: Arc::new(StylusThreadData {
+                up,
+                down: down.into(),
+            }),
+        }
+    }
+
+    unsafe fn launch_new_wavm(
+        &self,
+        params: StylusLaunchParams,
+    ) -> (Result<UserOutcome>, u64) {
+        let evm_api = JsEvmApi::new(params.evm_api_ids.clone(), self.clone());
+        let instance =
+            NativeInstance::deserialize(&params.module, params.compile.clone(), evm_api, params.evm_data);
+        let mut instance = match instance {
+            Ok(instance) => instance,
+            Err(error) => {
+                let message = format!("failed to instantiate program {error:?}");
+                self.data.up.send(UpMsg::Panic(message.clone())).unwrap();
+                panic!("{message}");
+            }
+        };
+
+        let outcome = instance.run_main(&params.calldata, params.config, params.ink);
+
+        let ink_left: u64 = match outcome {
+            Ok(UserOutcome::OutOfStack) => 0, // take all ink when out of stack
+            _ => instance.ink_left().into(),
+        };
+        (outcome, ink_left)
     }
 }
 
-impl JsCallIntoGo for ApiCaller {
+impl JsCallIntoGo for StylusThread {
     fn call_go(&mut self, func: u32, args: Vec<ApiValue>) -> Vec<ApiValue> {
-        let (tx, rx) = mpsc::sync_channel(0);
-        let msg = EvmMsg::Call(func, args, tx);
-        self.parent.send(msg).unwrap();
-        rx.recv().unwrap()
+        unsafe {
+            self.data
+                .up
+                .send(UpMsg::Call(func, args))
+                .expect("failed sending from stylus thread to go");
+            loop {
+                let msg = self.data.down.lock().unwrap().recv().unwrap();
+                match msg {
+                    DownMsg::CallResponse(res) => return res,
+                    DownMsg::ExecWasm(params) => {
+                        let (outcome, ink_left) =
+                            self.launch_new_wavm(params);
+                        self.data
+                            .up
+                            .send(UpMsg::WasmDone(outcome, ink_left))
+                            .expect("failed sending from stylus thread to go");
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl StylusThreadHandler {
+    fn increase_call(
+        &mut self,
+        timeout: Duration,
+    ) {
+        self.calls += 1;
+        if self.calls > 1 {
+            return;
+        }
+        let up_channel = mpsc::sync_channel(0);
+        let down_channel = mpsc::sync_channel(0);
+        let handler: thread::JoinHandle<()> = thread::spawn(move || unsafe {
+            let thread =
+                StylusThread::new(up_channel.0, down_channel.1);
+            // Safety: module came from compile_user_wasm
+            let msg = thread.data.down.lock().unwrap().recv().unwrap();
+            let DownMsg::ExecWasm(params) = msg else {
+                panic!("stylus thread got wrong message")
+            };
+            let (outcome, ink_left) = thread.launch_new_wavm(params);
+            thread
+                .data
+                .up
+                .send(UpMsg::WasmDone(outcome, ink_left))
+                .expect("failed replying from stylus thread");
+        });
+        self.thread_info = Some((down_channel.0, up_channel.1, handler));
+        self.timeout = timeout;
+    }
+
+    fn decrease_call(&mut self) {
+        self.calls -= 1;
+        if self.calls > 0 {
+            return;
+        }
+        let (_, _, handler) = self.thread_info.take().expect("stylus thread not found");
+        handler.join().expect("failed joining stylus thread");
+    }
+
+    fn send(&mut self, msg: DownMsg) -> Result<()> {
+        let (ref down, _, _) = self.thread_info.as_mut().expect("stylus thread not found");
+        match down.send(msg) {
+            Ok(_) => Ok(()),
+            Err(err) => bail!("{}", err.red()),
+        }
+    }
+
+    fn recv(&mut self) -> Result<UpMsg> {
+        let (_, ref up, _) = self.thread_info.as_mut().expect("stylus thread not found");
+        match up.recv_timeout(self.timeout) {
+            Ok(msg) => Ok(msg),
+            Err(err) => bail!("{}", err.red()),
+        }
     }
 }
 
@@ -57,46 +167,24 @@ pub(super) fn exec_wasm(
     calldata: Vec<u8>,
     compile: CompileConfig,
     config: StylusConfig,
-    evm_api: Vec<u8>,
+    evm_api_ids: Vec<u8>,
     evm_data: EvmData,
     ink: u64,
 ) -> Result<(Result<UserOutcome>, u64)> {
-    use EvmMsg::*;
-    use UserOutcomeKind::*;
+    use UpMsg::*;
 
-    let (tx, rx) = mpsc::sync_channel(0);
-    let evm_api = JsEvmApi::new(evm_api, ApiCaller::new(tx.clone()));
+    let (env, mut store) = env.data_and_store_mut();
 
-    let handle = thread::spawn(move || unsafe {
-        // Safety: module came from compile_user_wasm
-        let instance = NativeInstance::deserialize(&module, compile.clone(), evm_api, evm_data);
-        let mut instance = match instance {
-            Ok(instance) => instance,
-            Err(error) => {
-                let message = format!("failed to instantiate program {error:?}");
-                tx.send(Panic(message.clone())).unwrap();
-                panic!("{message}");
-            }
-        };
+    env.stylus_thread_handler
+        .increase_call(env.process.child_timeout);
 
-        let outcome = instance.run_main(&calldata, config, ink);
-        tx.send(Done).unwrap();
-
-        let ink_left = match outcome.as_ref().map(|e| e.into()) {
-            Ok(OutOfStack) => 0, // take all ink when out of stack
-            _ => instance.ink_left().into(),
-        };
-        (outcome, ink_left)
-    });
+    env.stylus_thread_handler
+        .send(DownMsg::ExecWasm(StylusLaunchParams{evm_api_ids, evm_data, module, calldata, ink, compile, config}))?;
 
     loop {
-        let msg = match rx.recv_timeout(env.data().process.child_timeout) {
-            Ok(msg) => msg,
-            Err(err) => bail!("{}", err.red()),
-        };
+        let msg = env.stylus_thread_handler.recv()?;
         match msg {
-            Call(func, args, respond) => {
-                let (env, mut store) = env.data_and_store_mut();
+            Call(func, args) => {
                 let js = &mut env.js_state;
 
                 let mut objects = vec![];
@@ -134,12 +222,14 @@ pub(super) fn exec_wasm(
                 for id in object_ids {
                     env.js_state.pool.remove(id);
                 }
-                respond.send(outs).unwrap();
+                env.stylus_thread_handler
+                    .send(DownMsg::CallResponse(outs))?;
             }
             Panic(error) => bail!(error),
-            Done => break,
+            WasmDone(res, ink_left) => {
+                env.stylus_thread_handler.decrease_call();
+                return Ok((res, ink_left));
+            }
         }
     }
-
-    Ok(handle.join().unwrap())
 }


### PR DESCRIPTION
instead of using separate thread per call in jit - keep the same thread per parent call.