### PR TITLE
Avoid crash when missing memory

### DIFF
--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -162,7 +162,15 @@ pub unsafe extern "C" fn stylus_call(
     let instance = unsafe { NativeInstance::deserialize(module, compile, go_api, evm_data) };
     let mut instance = match instance {
         Ok(instance) => instance,
-        Err(error) => panic!("failed to instantiate program: {error:?}"),
+        Err(error) => {
+            // TODO: adopt change where we require programs have memories
+            if format!("{error:?}").contains("Missing export memory") {
+                output.write_err(error.wrap_err("call failed"));
+                *gas = 0;
+                return UserOutcomeKind::Failure;
+            }
+            panic!("failed to instantiate program: {error:?}")
+        }
     };
 
     let status = match instance.run_main(&calldata, config, ink) {


### PR DESCRIPTION
Avoids a panic when calling a program that's missing a memory.

This will soon be rejected at compilation time in
- #141 