### PR TITLE
Add support for StylusArbOSVersion

### DIFF
--- a/arbnode/execution/blockchain.go
+++ b/arbnode/execution/blockchain.go
@@ -18,10 +18,12 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/params"
+
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/gethhook"
+	"github.com/offchainlabs/nitro/precompiles"
 	"github.com/offchainlabs/nitro/statetransfer"
 )
 
@@ -104,7 +106,15 @@ func WriteOrTestGenblock(chainDb ethdb.Database, initData statetransfer.InitData
 		}
 		timestamp = prevHeader.Time
 	}
-	stateRoot, err := arbosState.InitializeArbosInDatabase(chainDb, initData, chainConfig, initMessage, timestamp, accountsPerSync)
+	stateRoot, err := arbosState.InitializeArbosInDatabase(
+		chainDb,
+		initData,
+		chainConfig,
+		initMessage,
+		timestamp,
+		accountsPerSync,
+		precompiles.ArbOSVersionPrecompileAddresses(chainConfig),
+	)
 	if err != nil {
 		return err
 	}

--- a/arbos/arbosState/arbosstate_test.go
+++ b/arbos/arbosState/arbosstate_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestStorageOpenFromEmpty(t *testing.T) {
-	NewArbosMemoryBackedArbOSState()
+	NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 }
 
 func TestMemoryBackingEvmStorage(t *testing.T) {
@@ -44,16 +44,16 @@ func TestMemoryBackingEvmStorage(t *testing.T) {
 }
 
 func TestStorageBackedInt64(t *testing.T) {
-	state, _ := NewArbosMemoryBackedArbOSState()
-	storage := state.backingStorage
+	state, _ := NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
+	backingStorage := state.backingStorage
 	offset := uint64(7895463)
 
 	valuesToTry := []int64{0, 7, -7, 56487423567, -7586427647}
 
 	for _, val := range valuesToTry {
-		sbi := storage.OpenStorageBackedInt64(offset)
+		sbi := backingStorage.OpenStorageBackedInt64(offset)
 		Require(t, sbi.Set(val))
-		sbi = storage.OpenStorageBackedInt64(offset)
+		sbi = backingStorage.OpenStorageBackedInt64(offset)
 		res, err := sbi.Get()
 		Require(t, err)
 		if val != res {
@@ -63,7 +63,7 @@ func TestStorageBackedInt64(t *testing.T) {
 }
 
 func TestStorageSlots(t *testing.T) {
-	state, _ := NewArbosMemoryBackedArbOSState()
+	state, _ := NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 	sto := state.BackingStorage().OpenSubStorage([]byte{})
 
 	println("nil address", colors.Blue, storage.NilAddressRepresentation.String(), colors.Clear)

--- a/arbos/arbosState/initialization_test.go
+++ b/arbos/arbosState/initialization_test.go
@@ -60,7 +60,15 @@ func tryMarshalUnmarshal(input *statetransfer.ArbosInitializationInfo, t *testin
 
 	initReader := statetransfer.NewMemoryInitDataReader(&initData)
 	chainConfig := params.ArbitrumDevTestChainConfig()
-	stateroot, err := InitializeArbosInDatabase(raw, initReader, chainConfig, arbostypes.TestInitMessage, 0, 0)
+	stateroot, err := InitializeArbosInDatabase(
+		raw,
+		initReader,
+		chainConfig,
+		arbostypes.TestInitMessage,
+		0,
+		0,
+		make(map[uint64][]common.Address),
+	)
 	Require(t, err)
 
 	stateDb, err := state.New(stateroot, state.NewDatabase(raw), nil)

--- a/arbos/arbosState/initialize.go
+++ b/arbos/arbosState/initialize.go
@@ -50,7 +50,15 @@ func MakeGenesisBlock(parentHash common.Hash, blockNumber uint64, timestamp uint
 	return types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil))
 }
 
-func InitializeArbosInDatabase(db ethdb.Database, initData statetransfer.InitDataReader, chainConfig *params.ChainConfig, initMessage *arbostypes.ParsedInitMessage, timestamp uint64, accountsPerSync uint) (common.Hash, error) {
+func InitializeArbosInDatabase(
+	db ethdb.Database,
+	initData statetransfer.InitDataReader,
+	chainConfig *params.ChainConfig,
+	initMessage *arbostypes.ParsedInitMessage,
+	timestamp uint64,
+	accountsPerSync uint,
+	arbosVersionPrecompileAddresses map[uint64][]common.Address,
+) (common.Hash, error) {
 	stateDatabase := state.NewDatabase(db)
 	statedb, err := state.New(common.Hash{}, stateDatabase, nil)
 	if err != nil {
@@ -74,7 +82,7 @@ func InitializeArbosInDatabase(db ethdb.Database, initData statetransfer.InitDat
 	}
 
 	burner := burn.NewSystemBurner(nil, false)
-	arbosState, err := InitializeArbosState(statedb, burner, chainConfig, initMessage)
+	arbosState, err := InitializeArbosState(statedb, burner, chainConfig, initMessage, arbosVersionPrecompileAddresses)
 	if err != nil {
 		log.Crit("failed to open the ArbOS state", "error", err)
 	}

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -43,7 +43,12 @@ func InternalTxStartBlock(
 	}
 }
 
-func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.ArbosState, evm *vm.EVM) error {
+func ApplyInternalTxUpdate(
+	tx *types.ArbitrumInternalTx,
+	state *arbosState.ArbosState,
+	evm *vm.EVM,
+	arbosVersionPrecompileAddresses map[uint64][]common.Address,
+) error {
 	if len(tx.Data) < 4 {
 		return fmt.Errorf("internal tx data is too short (only %v bytes, at least 4 required)", len(tx.Data))
 	}
@@ -88,7 +93,12 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 
 		state.L2PricingState().UpdatePricingModel(l2BaseFee, timePassed, false)
 
-		return state.UpgradeArbosVersionIfNecessary(currentTime, evm.StateDB, evm.ChainConfig())
+		return state.UpgradeArbosVersionIfNecessary(
+			currentTime,
+			evm.StateDB,
+			evm.ChainConfig(),
+			arbosVersionPrecompileAddresses,
+		)
 	case InternalTxBatchPostingReportMethodID:
 		inputs, err := util.UnpackInternalTxDataBatchPostingReport(tx.Data)
 		if err != nil {

--- a/arbos/l1pricing_test.go
+++ b/arbos/l1pricing_test.go
@@ -313,7 +313,7 @@ func _withinOnePercent(v1, v2 *big.Int) bool {
 
 func newMockEVMForTesting() *vm.EVM {
 	chainConfig := params.ArbitrumDevTestChainConfig()
-	_, statedb := arbosState.NewArbosMemoryBackedArbOSState()
+	_, statedb := arbosState.NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 	context := vm.BlockContext{
 		BlockNumber: big.NewInt(0),
 		GasLimit:    ^uint64(0),

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -59,6 +59,7 @@ var ErrProgramActivation = errors.New("program activation failed")
 var ProgramNotActivatedError func() error
 var ProgramOutOfDateError func(version uint16) error
 var ProgramUpToDateError func() error
+var ProgramStylusDisabledError func() error
 
 const MaxWasmSize = 128 * 1024
 const initialFreePages = 2

--- a/arbos/queue_test.go
+++ b/arbos/queue_test.go
@@ -6,14 +6,15 @@ package arbos
 import (
 	"testing"
 
-	"github.com/offchainlabs/nitro/arbos/arbosState"
+	"github.com/ethereum/go-ethereum/common"
 
+	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/storage"
 	"github.com/offchainlabs/nitro/arbos/util"
 )
 
 func TestQueue(t *testing.T) {
-	state, statedb := arbosState.NewArbosMemoryBackedArbOSState()
+	state, statedb := arbosState.NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 	sto := state.BackingStorage().OpenSubStorage([]byte{})
 	Require(t, storage.InitializeQueue(sto))
 	q := storage.OpenQueue(sto)

--- a/arbos/retryable_test.go
+++ b/arbos/retryable_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestOpenNonexistentRetryable(t *testing.T) {
-	state, _ := arbosState.NewArbosMemoryBackedArbOSState()
+	state, _ := arbosState.NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 	id := common.BigToHash(big.NewInt(978645611142))
 	retryable, err := state.RetryableState().OpenRetryable(id, 0)
 	Require(t, err)
@@ -34,7 +34,7 @@ func TestOpenNonexistentRetryable(t *testing.T) {
 
 func TestRetryableLifecycle(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
-	state, statedb := arbosState.NewArbosMemoryBackedArbOSState()
+	state, statedb := arbosState.NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 	retryableState := state.RetryableState()
 
 	lifetime := uint64(retryables.RetryableLifetimeSeconds)
@@ -155,7 +155,7 @@ func TestRetryableLifecycle(t *testing.T) {
 
 func TestRetryableCleanup(t *testing.T) {
 	rand.Seed(time.Now().UTC().UnixNano())
-	state, statedb := arbosState.NewArbosMemoryBackedArbOSState()
+	state, statedb := arbosState.NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 	retryableState := state.RetryableState()
 
 	id := common.BigToHash(big.NewInt(rand.Int63n(1 << 32)))
@@ -184,7 +184,7 @@ func TestRetryableCleanup(t *testing.T) {
 }
 
 func TestRetryableCreate(t *testing.T) {
-	state, _ := arbosState.NewArbosMemoryBackedArbOSState()
+	state, _ := arbosState.NewArbosMemoryBackedArbOSState(make(map[uint64][]common.Address))
 	id := common.BigToHash(big.NewInt(978645611142))
 	lastTimestamp := uint64(0)
 

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -8,23 +8,21 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/l1pricing"
-
+	"github.com/offchainlabs/nitro/arbos/programs"
+	"github.com/offchainlabs/nitro/arbos/retryables"
 	"github.com/offchainlabs/nitro/arbos/util"
 	"github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 	"github.com/offchainlabs/nitro/util/arbmath"
 
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/ethereum/go-ethereum/params"
-	"github.com/offchainlabs/nitro/arbos/retryables"
-
-	"github.com/offchainlabs/nitro/arbos/arbosState"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	glog "github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 )
 
 var arbosAddress = types.ArbosAddress
@@ -110,6 +108,10 @@ func takeFunds(pool *big.Int, take *big.Int) *big.Int {
 func (p *TxProcessor) ExecuteWASM(scope *vm.ScopeContext, input []byte, interpreter *vm.EVMInterpreter) ([]byte, error) {
 	contract := scope.Contract
 	acting := contract.Address()
+
+	if !interpreter.Evm().ChainConfig().ArbitrumStylusEnabled(p.state.ArbOSVersion()) {
+		return nil, programs.ProgramStylusDisabledError()
+	}
 
 	var tracingInfo *util.TracingInfo
 	if interpreter.Config().Tracer != nil {

--- a/cmd/replay/main.go
+++ b/cmd/replay/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/offchainlabs/nitro/cmd/chaininfo"
 	"github.com/offchainlabs/nitro/das/dastree"
 	"github.com/offchainlabs/nitro/gethhook"
+	"github.com/offchainlabs/nitro/precompiles"
 	"github.com/offchainlabs/nitro/wavmio"
 )
 
@@ -257,7 +258,13 @@ func main() {
 			}
 		}
 
-		_, err = arbosState.InitializeArbosState(statedb, burn.NewSystemBurner(nil, false), chainConfig, initMessage)
+		_, err = arbosState.InitializeArbosState(
+			statedb,
+			burn.NewSystemBurner(nil, false),
+			chainConfig,
+			initMessage,
+			precompiles.ArbOSVersionPrecompileAddresses(chainConfig),
+		)
 		if err != nil {
 			panic(fmt.Sprintf("Error initializing ArbOS: %v", err.Error()))
 		}

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -10,6 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/precompiles"
 )
@@ -56,7 +58,8 @@ func init() {
 	}
 
 	precompileErrors := make(map[[4]byte]abi.Error)
-	for addr, precompile := range precompiles.Precompiles() {
+	// Precompile ArbOS version ignored during init, so specific ChainConfig version doesn't matter
+	for addr, precompile := range precompiles.Precompiles(params.ArbitrumOneChainConfig()) {
 		for _, errABI := range precompile.Precompile().GetErrorABIs() {
 			var id [4]byte
 			copy(id[:], errABI.ID[:4])

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -48,7 +48,7 @@ func (p ArbosPrecompileWrapper) RunAdvanced(
 func init() {
 	core.ReadyEVMForL2 = func(evm *vm.EVM, msg *core.Message) {
 		if evm.ChainConfig().IsArbitrum() {
-			evm.ProcessingHook = arbos.NewTxProcessor(evm, msg)
+			evm.ProcessingHook = arbos.NewTxProcessor(evm, msg, precompiles.ArbOSVersionPrecompileAddresses(evm.ChainConfig()))
 		}
 	}
 

--- a/gethhook/geth_test.go
+++ b/gethhook/geth_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/util"
+	"github.com/offchainlabs/nitro/precompiles"
 	"github.com/offchainlabs/nitro/util/testhelpers"
 )
 
@@ -54,7 +55,7 @@ var testChainConfig = &params.ChainConfig{
 
 func TestEthDepositMessage(t *testing.T) {
 
-	_, statedb := arbosState.NewArbosMemoryBackedArbOSState()
+	_, statedb := arbosState.NewArbosMemoryBackedArbOSState(precompiles.ArbOSVersionPrecompileAddresses(params.ArbitrumDevTestChainConfig()))
 	addr := common.HexToAddress("0x32abcdeffffff")
 	balance := common.BigToHash(big.NewInt(789789897789798))
 	balance2 := common.BigToHash(big.NewInt(98))

--- a/nodeInterface/virtual-contracts.go
+++ b/nodeInterface/virtual-contracts.go
@@ -41,11 +41,11 @@ func init() {
 
 	nodeInterfaceImpl := &NodeInterface{Address: types.NodeInterfaceAddress}
 	nodeInterfaceMeta := node_interfacegen.NodeInterfaceMetaData
-	_, nodeInterface := precompiles.MakePrecompile(nodeInterfaceMeta, nodeInterfaceImpl)
+	_, nodeInterface := precompiles.MakePrecompile(nodeInterfaceMeta, nodeInterfaceImpl, 1)
 
 	nodeInterfaceDebugImpl := &NodeInterfaceDebug{Address: types.NodeInterfaceDebugAddress}
 	nodeInterfaceDebugMeta := node_interfacegen.NodeInterfaceDebugMetaData
-	_, nodeInterfaceDebug := precompiles.MakePrecompile(nodeInterfaceDebugMeta, nodeInterfaceDebugImpl)
+	_, nodeInterfaceDebug := precompiles.MakePrecompile(nodeInterfaceDebugMeta, nodeInterfaceDebugImpl, 1)
 
 	core.InterceptRPCMessage = func(
 		msg *core.Message,

--- a/precompiles/ArbAddressTable_test.go
+++ b/precompiles/ArbAddressTable_test.go
@@ -156,7 +156,7 @@ func newMockEVMForTesting() *vm.EVM {
 
 func newMockEVMForTestingWithVersionAndRunMode(version *uint64, runMode core.MessageRunMode) *vm.EVM {
 	evm := newMockEVMForTestingWithVersion(version)
-	evm.ProcessingHook = arbos.NewTxProcessor(evm, &core.Message{TxRunMode: runMode})
+	evm.ProcessingHook = arbos.NewTxProcessor(evm, &core.Message{TxRunMode: runMode}, ArbOSVersionPrecompileAddresses(evm.ChainConfig()))
 	return evm
 }
 
@@ -165,7 +165,7 @@ func newMockEVMForTestingWithVersion(version *uint64) *vm.EVM {
 	if version != nil {
 		chainConfig.ArbitrumChainParams.InitialArbOSVersion = *version
 	}
-	_, statedb := arbosState.NewArbosMemoryBackedArbOSState()
+	_, statedb := arbosState.NewArbosMemoryBackedArbOSState(ArbOSVersionPrecompileAddresses(chainConfig))
 	context := vm.BlockContext{
 		BlockNumber: big.NewInt(0),
 		GasLimit:    ^uint64(0),

--- a/precompiles/ArbRetryableTx_test.go
+++ b/precompiles/ArbRetryableTx_test.go
@@ -7,9 +7,10 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/offchainlabs/nitro/arbos/storage"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+
+	"github.com/offchainlabs/nitro/arbos/storage"
 	templates "github.com/offchainlabs/nitro/solgen/go/precompilesgen"
 )
 
@@ -44,7 +45,7 @@ func TestRetryableRedeem(t *testing.T) {
 	Require(t, err)
 
 	retryAddress := common.HexToAddress("6e")
-	_, gasLeft, err := Precompiles()[retryAddress].Call(
+	_, gasLeft, err := Precompiles(params.ArbitrumDevTestChainConfig())[retryAddress].Call(
 		redeemCalldata,
 		retryAddress,
 		retryAddress,

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -6,9 +6,10 @@ package precompiles
 type ArbWasm struct {
 	Address addr // 0x71
 
-	ProgramNotActivatedError func() error
-	ProgramOutOfDateError    func(version uint16) error
-	ProgramUpToDateError     func() error
+	ProgramNotActivatedError   func() error
+	ProgramOutOfDateError      func(version uint16) error
+	ProgramUpToDateError       func() error
+	ProgramStylusDisabledError func() error
 }
 
 // Compile a wasm program with the latest instrumentation

--- a/precompiles/precompile_test.go
+++ b/precompiles/precompile_test.go
@@ -25,7 +25,7 @@ func TestEvents(t *testing.T) {
 	evm.Context.BlockNumber = big.NewInt(int64(blockNumber))
 
 	debugContractAddr := common.HexToAddress("ff")
-	contract := Precompiles()[debugContractAddr]
+	contract := Precompiles(params.ArbitrumDevTestChainConfig())[debugContractAddr]
 
 	var method *PrecompileMethod
 	for _, available := range contract.Precompile().methods {
@@ -130,7 +130,7 @@ func TestEvents(t *testing.T) {
 
 func TestEventCosts(t *testing.T) {
 	debugContractAddr := common.HexToAddress("ff")
-	contract := Precompiles()[debugContractAddr]
+	contract := Precompiles(params.ArbitrumDevTestChainConfig())[debugContractAddr]
 
 	//nolint:errcheck
 	impl := contract.Precompile().implementer.Interface().(*ArbDebug)

--- a/system_tests/precompile_fuzz_test.go
+++ b/system_tests/precompile_fuzz_test.go
@@ -33,7 +33,13 @@ func FuzzPrecompiles(f *testing.F) {
 		}
 		burner := burn.NewSystemBurner(nil, false)
 		chainConfig := params.ArbitrumDevTestChainConfig()
-		_, err = arbosState.InitializeArbosState(sdb, burner, chainConfig, arbostypes.TestInitMessage)
+		_, err = arbosState.InitializeArbosState(
+			sdb,
+			burner,
+			chainConfig,
+			arbostypes.TestInitMessage,
+			precompiles.ArbOSVersionPrecompileAddresses(chainConfig),
+		)
 		if err != nil {
 			panic(err)
 		}

--- a/system_tests/precompile_fuzz_test.go
+++ b/system_tests/precompile_fuzz_test.go
@@ -61,7 +61,7 @@ func FuzzPrecompiles(f *testing.F) {
 		addr[19] = precompileSelector
 
 		// Pick a precompile method based on the second byte of the input
-		if precompile := precompiles.Precompiles()[addr]; precompile != nil {
+		if precompile := precompiles.Precompiles(params.ArbitrumDevTestChainConfig())[addr]; precompile != nil {
 			sigs := precompile.Precompile().Get4ByteMethodSignatures()
 			if int(methodSelector) < len(sigs) {
 				newInput := make([]byte, 4)

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -967,15 +967,47 @@ func testSdkStorage(t *testing.T, jit bool) {
 	check()
 }
 
-func setupProgramTest(t *testing.T, jit bool) (
+func TestStylusDisabled(t *testing.T) {
+	t.Parallel()
+	testStylusDisabled(t, true)
+}
+
+func testStylusDisabled(t *testing.T, jit bool) {
+	chainConfig := params.ArbitrumDevTestChainConfig()
+	chainConfig.ArbitrumChainParams.StylusArbOSVersion = 0
+	ctx, node, _, l2client, auth, cleanup := setupProgramTestAdvanced(t, jit, chainConfig)
+	defer cleanup()
+	_, _, _, _, err := deployWasmImpl(t, ctx, auth, l2client, rustFile("keccak"))
+	if err == nil || !strings.Contains(err.Error(), "invalid code: must not begin with 0xef") {
+		Fatal(t, "deploy should have failed", err)
+	}
+
+	code, err := l2client.CodeAt(ctx, types.ArbWasmAddress, nil)
+	Require(t, err)
+	if len(code) != 0 {
+		Fatal(t, "code found at ArbWasm address")
+	}
+	nonce, err := l2client.NonceAt(ctx, types.ArbWasmAddress, nil)
+	Require(t, err)
+	if nonce != 0 {
+		Fatal(t, "ArbWasm nonce is not 0", nonce)
+	}
+
+	arbWasm, err := precompilesgen.NewArbWasm(types.ArbWasmAddress, l2client)
+	Require(t, err)
+	_, err = arbWasm.StylusVersion(nil)
+	if err == nil || !strings.Contains(err.Error(), "stylus precompiles are disabled") {
+		Fatal(t, "stylus precompiles not disabled", err)
+	}
+
+	validateBlocks(t, 1, jit, ctx, node, l2client)
+}
+
+func setupProgramTestAdvanced(t *testing.T, jit bool, chainConfig *params.ChainConfig) (
 	context.Context, *arbnode.Node, *BlockchainTestInfo, *ethclient.Client, bind.TransactOpts, func(),
 ) {
 	ctx, cancel := context.WithCancel(context.Background())
 	rand.Seed(time.Now().UTC().UnixNano())
-
-	// TODO: track latest ArbOS version
-	chainConfig := params.ArbitrumDevTestChainConfig()
-	chainConfig.ArbitrumChainParams.InitialArbOSVersion = 10
 
 	l2config := arbnode.ConfigDefaultL1Test()
 	l2config.BlockValidator.Enable = false
@@ -1021,6 +1053,12 @@ func setupProgramTest(t *testing.T, jit bool) (
 	return ctx, node, l2info, l2client, auth, cleanup
 }
 
+func setupProgramTest(t *testing.T, jit bool) (
+	context.Context, *arbnode.Node, *BlockchainTestInfo, *ethclient.Client, bind.TransactOpts, func(),
+) {
+	return setupProgramTestAdvanced(t, jit, params.ArbitrumDevTestChainConfig())
+}
+
 func readWasmFile(t *testing.T, file string) ([]byte, []byte) {
 	name := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 	source, err := os.ReadFile(file)
@@ -1038,15 +1076,26 @@ func readWasmFile(t *testing.T, file string) ([]byte, []byte) {
 	return wasm, wasmSource
 }
 
-func deployWasm(
+func deployWasmImpl(
 	t *testing.T, ctx context.Context, auth bind.TransactOpts, l2client *ethclient.Client, file string,
-) common.Address {
+) (string, []byte, []byte, common.Address, error) {
 	name := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
 	wasm, uncompressed := readWasmFile(t, file)
 	auth.GasLimit = 32000000 // skip gas estimation
-	program := deployContract(t, ctx, auth, l2client, wasm)
-	colors.PrintGrey(name, ": deployed to ", program.Hex())
-	activateWasm(t, ctx, auth, l2client, program, name)
+	program, err := deployContractImpl(t, ctx, auth, l2client, wasm)
+	if err == nil {
+		colors.PrintGrey(name, ": deployed to ", program.Hex())
+		activateWasm(t, ctx, auth, l2client, program, name)
+	}
+
+	return name, wasm, uncompressed, program, err
+}
+
+func deployWasm(
+	t *testing.T, ctx context.Context, auth bind.TransactOpts, l2client *ethclient.Client, file string,
+) common.Address {
+	name, wasm, uncompressed, program, err := deployWasmImpl(t, ctx, auth, l2client, file)
+	Require(t, err)
 
 	// check that program size matches
 	arbWasm, err := precompilesgen.NewArbWasm(types.ArbWasmAddress, l2client)

--- a/system_tests/state_fuzz_test.go
+++ b/system_tests/state_fuzz_test.go
@@ -20,12 +20,14 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
+
 	"github.com/offchainlabs/nitro/arbcompress"
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
 	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/l2pricing"
 	"github.com/offchainlabs/nitro/arbstate"
+	"github.com/offchainlabs/nitro/precompiles"
 	"github.com/offchainlabs/nitro/statetransfer"
 )
 
@@ -140,6 +142,7 @@ func FuzzStateTransition(f *testing.F) {
 			initMessage,
 			0,
 			0,
+			precompiles.ArbOSVersionPrecompileAddresses(chainConfig),
 		)
 		if err != nil {
 			panic(err)

--- a/system_tests/stylus_test.go
+++ b/system_tests/stylus_test.go
@@ -55,3 +55,22 @@ func TestProgramArbitratorActivateFails(t *testing.T) {
 	t.Parallel()
 	testActivateFails(t, false)
 }
+
+func TestProgramArbitratorSdkStorage(t *testing.T) {
+	t.Parallel()
+	testSdkStorage(t, false)
+}
+
+func TestProgramArbitratorPreStylus(t *testing.T) {
+	t.Parallel()
+	testPreStylus(t, false)
+}
+func TestProgramArbitratorStylusDisabled(t *testing.T) {
+	t.Parallel()
+	testStylusDisabled(t, false)
+}
+
+func TestProgramArbitratorStylusEnabled(t *testing.T) {
+	t.Parallel()
+	testStylusEnabled(t, false)
+}


### PR DESCRIPTION
Add chain parameter StylusArbOSVersion to gate enabling Stylus to a specific ArbOS version