### PR TITLE
Program activated event edits

### DIFF
--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -176,36 +176,36 @@ func (p Programs) ActivateProgram(evm *vm.EVM, address common.Address, debugMode
 
 	version, err := p.StylusVersion()
 	if err != nil {
-		return common.Hash{}, 0, false, err
+		return codeHash, 0, false, err
 	}
 	latest, err := p.CodehashVersion(codeHash)
 	if err != nil {
-		return common.Hash{}, 0, false, err
+		return codeHash, 0, false, err
 	}
 	// Already compiled and found in the machine versions mapping.
 	if latest >= version {
-		return common.Hash{}, 0, false, ProgramUpToDateError()
+		return codeHash, 0, false, ProgramUpToDateError()
 	}
 	wasm, err := getWasm(statedb, address)
 	if err != nil {
-		return common.Hash{}, 0, false, err
+		return codeHash, 0, false, err
 	}
 
 	// require the program's footprint not exceed the remaining memory budget
 	pageLimit, err := p.PageLimit()
 	if err != nil {
-		return common.Hash{}, 0, false, err
+		return codeHash, 0, false, err
 	}
 	pageLimit = arbmath.SaturatingUSub(pageLimit, statedb.GetStylusPagesOpen())
 
 	// charge 3 million up front to begin compilation
 	burner := p.programs.Burner()
 	if err := burner.Burn(3000000); err != nil {
-		return common.Hash{}, 0, false, err
+		return codeHash, 0, false, err
 	}
 	info, compiledHash, err := compileUserWasm(statedb, address, wasm, pageLimit, version, debugMode, burner)
 	if err != nil {
-		return common.Hash{}, 0, true, err
+		return codeHash, 0, true, err
 	}
 
 	// wasmSize is stored as half kb units, rounding up

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -15,20 +15,14 @@ type ArbWasm struct {
 
 // Compile a wasm program with the latest instrumentation
 func (con ArbWasm) ActivateProgram(c ctx, evm mech, program addr) (uint16, error) {
-	codeHash, version, takeAllGas, err := c.State.Programs().ActivateProgram(evm, program, evm.ChainConfig().DebugMode())
+	programs := c.State.Programs()
+	codeHash, version, takeAllGas, err := programs.ActivateProgram(evm, program, evm.ChainConfig().DebugMode())
 	if takeAllGas {
 		_ = c.BurnOut()
 		return version, err
 	}
 	if err != nil {
 		return version, err
-	}
-	eventGas, err := con.ProgramActivatedGasCost(codeHash, program, version)
-	if err != nil {
-		return version, err
-	}
-	if c.gasLeft < eventGas {
-		return version, c.Burn(eventGas)
 	}
 	return version, con.ProgramActivated(c, evm, codeHash, program, version)
 }

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -884,18 +884,18 @@ func TestProgramAcivationLogs(t *testing.T) {
 	if len(receipt.Logs) != 1 {
 		Fatal(t, "expected 1 log while activating, got ", len(receipt.Logs))
 	}
-	parsed, err := arbWasm.ParseProgramActivated(*receipt.Logs[0])
+	log, err := arbWasm.ParseProgramActivated(*receipt.Logs[0])
 	if err != nil {
 		Fatal(t, "parsing activated log: ", err)
 	}
-	if parsed.Version == 0 {
+	if log.Version == 0 {
 		Fatal(t, "activated program with version 0")
 	}
-	if parsed.Program != programAddress {
-		Fatal(t, "unexpected program in activation log: ", parsed.Program)
+	if log.Program != programAddress {
+		Fatal(t, "unexpected program in activation log: ", log.Program)
 	}
-	if !bytes.Equal(crypto.Keccak256(wasm), parsed.Codehash[:]) {
-		Fatal(t, "unexpected codehash in activation log: ", parsed.Codehash)
+	if crypto.Keccak256Hash(wasm) != log.Codehash {
+		Fatal(t, "unexpected codehash in activation log: ", log.Codehash)
 	}
 }
 


### PR DESCRIPTION
Updates the following with a few tweaks
- #149 

Notably
- Since `con.ProgramActivated` burns gas, we remove the prior gas check
- Minor type tweaks & renamings