### PR TITLE
Fix tracing memory leak

### DIFF
--- a/arbitrator/stylus/src/evm_api.rs
+++ b/arbitrator/stylus/src/evm_api.rs
@@ -69,7 +69,7 @@ pub struct GoEvmApi {
     pub add_pages: unsafe extern "C" fn(id: usize, pages: u16) -> u64, // gas cost
     pub capture_hostio: unsafe extern "C" fn(
         id: usize,
-        name: *mut RustBytes,
+        name: *mut RustSlice,
         args: *mut RustSlice,
         outs: *mut RustSlice,
         start_ink: u64,
@@ -264,7 +264,7 @@ impl EvmApi for GoEvmApi {
         call!(
             self,
             capture_hostio,
-            ptr!(RustBytes::new(name.as_bytes().to_vec())),
+            ptr!(RustSlice::new(name.as_bytes())),
             ptr!(RustSlice::new(args)),
             ptr!(RustSlice::new(outs)),
             start_ink,

--- a/arbos/programs/native_api.go
+++ b/arbos/programs/native_api.go
@@ -76,9 +76,9 @@ u64 addPagesWrap(usize api, u16 pages) {
     return addPagesImpl(api, pages);
 }
 
-void captureHostioImpl(usize api, RustSlice * name, RustSlice * data, u64 startInk, u64 endInk);
-void captureHostioWrap(usize api, RustSlice * name, RustSlice * data, u64 startInk, u64 endInk) {
-    return captureHostioImpl(api, name, data, startInk, endInk);
+void captureHostioImpl(usize api, RustSlice * name, RustSlice * data, RustSlice * outs, u64 startInk, u64 endInk);
+void captureHostioWrap(usize api, RustSlice * name, RustSlice * data, RustSlice * outs, u64 startInk, u64 endInk) {
+    return captureHostioImpl(api, name, data, outs, startInk, endInk);
 }
 */
 import "C"


### PR DESCRIPTION
Fixes a small memory leak in the tracing API by resolving an inconsistency in `capture-hostio`