### PR TITLE
Error Recovery Policy

### DIFF
--- a/arbitrator/prover/src/error_guard.rs
+++ b/arbitrator/prover/src/error_guard.rs
@@ -1,0 +1,113 @@
+// Copyright 2022-2023, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+use crate::{
+    machine::hash_stack,
+    value::{ProgramCounter, Value},
+};
+use arbutil::{Bytes32, Color};
+use digest::Digest;
+use sha3::Keccak256;
+use std::{
+    fmt::{self, Display},
+    ops::{Deref, DerefMut},
+};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ErrorGuardStack {
+    pub guards: Vec<ErrorGuard>,
+    pub enabled: bool,
+}
+
+impl Deref for ErrorGuardStack {
+    type Target = Vec<ErrorGuard>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guards
+    }
+}
+
+impl DerefMut for ErrorGuardStack {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guards
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ErrorGuard {
+    pub frame_stack: usize,
+    pub value_stack: usize,
+    pub inter_stack: usize,
+    pub on_error: ProgramCounter,
+}
+
+impl Display for ErrorGuard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{} {} {} {} {}{}",
+            "ErrorGuard(".grey(),
+            self.frame_stack.mint(),
+            self.value_stack.mint(),
+            self.inter_stack.mint(),
+            "→".grey(),
+            self.on_error,
+            ")".grey(),
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ErrorGuardProof {
+    frame_stack: Bytes32,
+    value_stack: Bytes32,
+    inter_stack: Bytes32,
+    on_error: ProgramCounter,
+}
+
+impl ErrorGuardProof {
+    const STACK_PREFIX_ON: &'static str = "Guard stack (on):";
+    const STACK_PREFIX_OFF: &'static str = "Guard stack (off):";
+    const GUARD_PREFIX: &'static str = "Error guard:";
+
+    pub fn new(
+        frame_stack: Bytes32,
+        value_stack: Bytes32,
+        inter_stack: Bytes32,
+        on_error: ProgramCounter,
+    ) -> Self {
+        Self {
+            frame_stack,
+            value_stack,
+            inter_stack,
+            on_error,
+        }
+    }
+
+    pub fn serialize_for_proof(&self) -> Vec<u8> {
+        let mut data = self.frame_stack.to_vec();
+        data.extend(self.value_stack.0);
+        data.extend(self.inter_stack.0);
+        data.extend(Value::from(self.on_error).serialize_for_proof());
+        data
+    }
+
+    fn hash(&self) -> Bytes32 {
+        Keccak256::new()
+            .chain(Self::GUARD_PREFIX)
+            .chain(self.frame_stack)
+            .chain(self.value_stack)
+            .chain(self.inter_stack)
+            .chain(Value::InternalRef(self.on_error).hash())
+            .finalize()
+            .into()
+    }
+
+    pub fn hash_guards(guards: &[Self], enabled: bool) -> Bytes32 {
+        let prefix = match enabled {
+            true => Self::STACK_PREFIX_ON,
+            false => Self::STACK_PREFIX_OFF,
+        };
+        hash_stack(guards.iter().map(|g| g.hash()), prefix)
+    }
+}

--- a/arbitrator/prover/src/host.rs
+++ b/arbitrator/prover/src/host.rs
@@ -75,6 +75,7 @@ pub enum Hostio {
     WavmHaltAndSetFinished,
     WavmLinkModule,
     WavmUnlinkModule,
+    WavmSetErrorPolicy,
     ProgramInkLeft,
     ProgramInkStatus,
     ProgramSetInk,
@@ -117,6 +118,7 @@ impl FromStr for Hostio {
             ("env", "wavm_halt_and_set_finished") => WavmHaltAndSetFinished,
             ("hostio", "wavm_link_module") => WavmLinkModule,
             ("hostio", "wavm_unlink_module") => WavmUnlinkModule,
+            ("hostio", "wavm_set_error_policy") => WavmSetErrorPolicy,
             ("hostio", "program_ink_left") => ProgramInkLeft,
             ("hostio", "program_ink_status") => ProgramInkStatus,
             ("hostio", "program_set_ink") => ProgramSetInk,
@@ -173,6 +175,7 @@ impl Hostio {
             WavmHaltAndSetFinished      => func!(),
             WavmLinkModule              => func!([I32], [I32]),      // λ(module_hash) → module
             WavmUnlinkModule            => func!(),                  // λ()
+            WavmSetErrorPolicy          => func!([I32]),             // λ(enabled)
             ProgramInkLeft              => func!([I32], [I64]),      // λ(module) → ink_left
             ProgramInkStatus            => func!([I32], [I32]),      // λ(module) → ink_status
             ProgramSetInk               => func!([I32, I64]),        // λ(module, ink_left)
@@ -286,6 +289,11 @@ impl Hostio {
             WavmUnlinkModule => {
                 // λ()
                 opcode!(UnlinkModule);
+            }
+            WavmSetErrorPolicy => {
+                // λ(status)
+                opcode!(LocalGet, 0);
+                opcode!(SetErrorPolicy);
             }
             ProgramInkLeft => {
                 // λ(module) → ink_left

--- a/arbitrator/prover/src/lib.rs
+++ b/arbitrator/prover/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]
 
 pub mod binary;
+mod error_guard;
 mod host;
 pub mod machine;
 /// cbindgen:ignore

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -2316,12 +2316,10 @@ impl Machine {
                         on_error: self.pc,
                     });
                     self.value_stack.push(1_u32.into());
-                    self.guards.enabled = true;
                     reset_refs!();
                 }
                 Opcode::PopErrorGuard => {
                     self.guards.pop();
-                    self.guards.enabled = false;
                 }
                 Opcode::SetErrorPolicy => {
                     let status = self.value_stack.pop().unwrap().assume_u32();

--- a/arbitrator/prover/src/wavm.rs
+++ b/arbitrator/prover/src/wavm.rs
@@ -165,6 +165,8 @@ pub enum Opcode {
     PushErrorGuard,
     /// Drops the innermost error scope
     PopErrorGuard,
+    /// Determines whether to bypass error scopes
+    SetErrorPolicy,
     /// Dynamically adds a module to the replay machine
     LinkModule,
     /// Dynamically removes the last module to the replay machine
@@ -286,6 +288,7 @@ impl Opcode {
             Opcode::UnlinkModule => 0x8024,
             Opcode::PushErrorGuard => 0x8025,
             Opcode::PopErrorGuard => 0x8026,
+            Opcode::SetErrorPolicy => 0x8027,
             Opcode::HaltAndSetFinished => 0x8022,
         }
     }

--- a/arbitrator/prover/test-cases/dynamic.wat
+++ b/arbitrator/prover/test-cases/dynamic.wat
@@ -1,11 +1,12 @@
 
 (module
-    (import "hostio" "wavm_link_module"   (func $link       (param i32)     (result i32)))
-    (import "hostio" "wavm_unlink_module" (func $unlink                                 ))
-    (import "hostio" "program_set_ink"    (func $set_ink    (param i32 i64)             ))
-    (import "hostio" "program_ink_left"   (func $ink_left   (param i32)     (result i64)))
-    (import "hostio" "program_ink_status" (func $ink_status (param i32)     (result i32)))
-    (import "hostio" "program_call_main"  (func $user_func  (param i32 i32) (result i32)))
+    (import "hostio" "wavm_link_module"      (func $link       (param i32)     (result i32)))
+    (import "hostio" "wavm_unlink_module"    (func $unlink                                 ))
+    (import "hostio" "wavm_set_error_policy" (func $set_policy (param i32)                 ))
+    (import "hostio" "program_set_ink"       (func $set_ink    (param i32 i64)             ))
+    (import "hostio" "program_ink_left"      (func $ink_left   (param i32)     (result i64)))
+    (import "hostio" "program_ink_status"    (func $ink_status (param i32)     (result i32)))
+    (import "hostio" "program_call_main"     (func $user_func  (param i32 i32) (result i32)))
 
     ;; WAVM Module hash
     (data (i32.const 0x0)
@@ -47,6 +48,10 @@
         (if
             (then (unreachable)))
 
+        (;; enable error recovery
+        i32.const 1
+        call $set_policy
+
         ;; recover from an unreachable
         local.get $user
         i32.const 2 ;; $unreachable
@@ -54,21 +59,21 @@
         i32.const 1 ;; indicates failure
         i32.ne
         (if
-            (then (unreachable)))
+            (then (unreachable));)
 
         ;; push some items to the stack
         i32.const 0xa4b0
         i64.const 0xa4b1
         i32.const 0xa4b2
 
-        ;; recover from an out-of-bounds memory access
+        (;; recover from an out-of-bounds memory access
         local.get $user
         i32.const 3 ;; $out_of_bounds
         call $user_func
         i32.const 1 ;; indicates failure
         i32.ne
         (if
-            (then (unreachable)))
+            (then (unreachable));)
 
         ;; drop the items from the stack
         drop

--- a/arbitrator/wasm-libraries/user-host/src/guard.rs
+++ b/arbitrator/wasm-libraries/user-host/src/guard.rs
@@ -1,0 +1,17 @@
+// Copyright 2023, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+#[link(wasm_import_module = "hostio")]
+extern "C" {
+    fn wavm_set_error_policy(status: u32);
+}
+
+#[repr(u32)]
+pub enum ErrorPolicy {
+    ChainHalt,
+    Recover,
+}
+
+pub unsafe fn set_error_policy(policy: ErrorPolicy) {
+    wavm_set_error_policy(policy as u32);
+}

--- a/arbitrator/wasm-libraries/user-host/src/lib.rs
+++ b/arbitrator/wasm-libraries/user-host/src/lib.rs
@@ -9,6 +9,7 @@ use evm_api::ApiCaller;
 use prover::programs::{meter::MeteredMachine, prelude::StylusConfig};
 
 mod evm_api;
+mod guard;
 mod host;
 mod ink;
 mod link;

--- a/precompiles/ArbDebug.go
+++ b/precompiles/ArbDebug.go
@@ -56,6 +56,11 @@ func (con ArbDebug) BecomeChainOwner(c ctx, evm mech) error {
 	return c.State.ChainOwners().Add(c.caller)
 }
 
+// Halts the chain by panicking in the STF
+func (con ArbDebug) Panic(c ctx, evm mech) error {
+	panic("called ArbDebug's debug-only Panic method")
+}
+
 func (con ArbDebug) LegacyError(c ctx) error {
 	return errors.New("example legacy error")
 }


### PR DESCRIPTION
This PR introduces the ability for the replay machine to enable & disable the error guard stack.

When disable, errors are unguarded, inducing a chain halt on failure. Though counter-intuitive, this ability turns certain theoretical classes of attacks into chain halts rather than arbitrary code execution in the STF -- not that any such attacks are known.

Associated PRs
- https://github.com/OffchainLabs/stylus-contracts/pull/23