### PR TITLE
arbnode: init broadcast server before sequencing

### DIFF
--- a/arbnode/node.go
+++ b/arbnode/node.go
@@ -1044,6 +1044,13 @@ func (n *Node) Start(ctx context.Context) error {
 			return fmt.Errorf("error starting inbox reader: %w", err)
 		}
 	}
+	// broadcastServer must be started befopre sequencing any transactions
+	if n.BroadcastServer != nil {
+		err = n.BroadcastServer.Start(ctx)
+		if err != nil {
+			return fmt.Errorf("error starting feed broadcast server: %w", err)
+		}
+	}
 	if n.DelayedSequencer != nil && n.SeqCoordinator == nil {
 		err = n.DelayedSequencer.ForceSequenceDelayed(ctx)
 		if err != nil {
@@ -1101,12 +1108,6 @@ func (n *Node) Start(ctx context.Context) error {
 	}
 	if n.L1Reader != nil {
 		n.L1Reader.Start(ctx)
-	}
-	if n.BroadcastServer != nil {
-		err = n.BroadcastServer.Start(ctx)
-		if err != nil {
-			return fmt.Errorf("error starting feed broadcast server: %w", err)
-		}
 	}
 	if n.BroadcastClients != nil {
 		go func() {


### PR DESCRIPTION
Cherrypick https://github.com/OffchainLabs/nitro/pull/1950 into stylus to fix `feedOneMsg failed to send message to execEngine err="createBlock mutex held"` bug