### PR TITLE
Activation Pricing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ clean:
 	rm -f arbitrator/wasm-libraries/soft-float/*.o
 	rm -f arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/*.o
 	rm -f arbitrator/wasm-libraries/soft-float/SoftFloat/build/Wasm-Clang/*.a
+	rm -f arbitrator/wasm-libraries/forward/*.wat
 	rm -rf arbitrator/stylus/tests/*/target/ arbitrator/stylus/tests/*/*.wasm
 	@rm -rf contracts/build contracts/cache solgen/go/
 	@rm -f .make/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021-2023, Offchain Labs, Inc.
+# Copyright 2021-2024, Offchain Labs, Inc.
 # For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 # Docker builds mess up file timestamps. Then again, in docker builds we never

--- a/arbitrator/jit/src/user/mod.rs
+++ b/arbitrator/jit/src/user/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 use crate::{

--- a/arbitrator/jit/src/user/mod.rs
+++ b/arbitrator/jit/src/user/mod.rs
@@ -33,7 +33,8 @@ mod evm_api;
 ///     λ(wasm []byte, pageLimit, version u16, debug u32, modHash *hash, gas *u64) (footprint u16, err *Vec<u8>)
 ///
 /// These values are placed on the stack as follows
-///     || wasm... || pageLimit | version | debug || modhash ptr || gas ptr || footprint | 6 pad || err ptr ||
+///     || wasm... || pageLimit | version | debug || modhash ptr || gas ptr || initGas | asmSize ||
+///     || footprint | 6 pad || err ptr ||
 ///
 pub fn stylus_activate(mut env: WasmEnvMut, sp: u32) {
     let mut sp = GoStack::simple(sp, &mut env);
@@ -50,19 +51,21 @@ pub fn stylus_activate(mut env: WasmEnvMut, sp: u32) {
             sp.write_u64_raw(gas, 0);
             sp.write_slice(module_hash, &Bytes32::default());
             sp.skip_space();
+            sp.skip_space();
             sp.write_ptr(heapify(error));
             return;
         }};
     }
 
     let gas_left = &mut sp.read_u64_raw(gas);
-    let (module, pages) = match Module::activate(&wasm, version, page_limit, debug, gas_left) {
+    let (module, info) = match Module::activate(&wasm, version, page_limit, debug, gas_left) {
         Ok(result) => result,
         Err(error) => error!(error),
     };
     sp.write_u64_raw(gas, *gas_left);
     sp.write_slice(module_hash, &module.hash().0);
-    sp.write_u16(pages).skip_space();
+    sp.write_u32(info.init_gas).write_u32(info.asm_size);
+    sp.write_u16(info.footprint).skip_space();
     sp.write_nullptr();
 }
 

--- a/arbitrator/jit/src/user/mod.rs
+++ b/arbitrator/jit/src/user/mod.rs
@@ -64,7 +64,7 @@ pub fn stylus_activate(mut env: WasmEnvMut, sp: u32) {
     };
     sp.write_u64_raw(gas, *gas_left);
     sp.write_slice(module_hash, &module.hash().0);
-    sp.write_u32(info.init_gas).write_u32(info.asm_size);
+    sp.write_u32(info.init_gas).write_u32(info.asm_estimate);
     sp.write_u16(info.footprint).skip_space();
     sp.write_nullptr();
 }

--- a/arbitrator/prover/src/binary.rs
+++ b/arbitrator/prover/src/binary.rs
@@ -572,7 +572,7 @@ impl<'a> WasmBinary<'a> {
         let user_main = self.check_func(STYLUS_ENTRY_POINT, ty)?;
 
         // naively assume for now an upper bound of 5Mb
-        let asm_size = 5 * 1024 * 1024;
+        let asm_estimate = 5 * 1024 * 1024;
 
         // TODO: determine safe value
         let init_gas = 2048;
@@ -584,7 +584,7 @@ impl<'a> WasmBinary<'a> {
             ink_status: ink_status.as_u32(),
             depth_left: depth_left.as_u32(),
             init_gas,
-            asm_size,
+            asm_estimate,
             footprint,
             user_main,
         })

--- a/arbitrator/prover/src/binary.rs
+++ b/arbitrator/prover/src/binary.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 use crate::{

--- a/arbitrator/prover/src/lib.rs
+++ b/arbitrator/prover/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 #![allow(clippy::missing_safety_doc, clippy::too_many_arguments)]

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -425,7 +425,7 @@ impl Module {
             bin.memories.len() <= 1,
             "Multiple memories are not supported"
         );
-        if let Some(limits) = bin.memories.get(0) {
+        if let Some(limits) = bin.memories.first() {
             let page_size = Memory::PAGE_SIZE;
             let initial = limits.initial; // validate() checks this is less than max::u32
             let allowed = u32::MAX as u64 / Memory::PAGE_SIZE - 1; // we require the size remain *below* 2^32

--- a/arbitrator/prover/src/programs/mod.rs
+++ b/arbitrator/prover/src/programs/mod.rs
@@ -363,15 +363,23 @@ impl<'a> ModuleMod for WasmBinary<'a> {
     }
 }
 
+/// Information about an activated program.
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
 pub struct StylusData {
-    pub ink_left: u32,   // global index
-    pub ink_status: u32, // global index
-    pub depth_left: u32, // global index
+    /// Global index for the amount of ink left.
+    pub ink_left: u32,
+    /// Global index for whether the program is out of ink.
+    pub ink_status: u32,
+    /// Global index for the amount of stack space remaining.
+    pub depth_left: u32,
+    /// Gas needed to invoke the program.
     pub init_gas: u32,
-    pub asm_size: u32,
+    /// Canonical estimate of the asm length in bytes.
+    pub asm_estimate: u32,
+    /// Initial memory size in pages.
     pub footprint: u16,
+    /// Entrypoint offset.
     pub user_main: u32,
 }
 

--- a/arbitrator/prover/src/programs/mod.rs
+++ b/arbitrator/prover/src/programs/mod.rs
@@ -401,6 +401,8 @@ impl Module {
         debug: bool,
         gas: &mut u64,
     ) -> Result<(Self, StylusData)> {
+        // converts a number of microseconds to gas
+        // TODO: collapse to a single value after finalizing factors
         let us_to_gas = |us: u64| {
             let fudge = 2;
             let sync_rate = 1_000_000 / 2;

--- a/arbitrator/prover/src/programs/mod.rs
+++ b/arbitrator/prover/src/programs/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     programs::config::CompileConfig,
     value::{FunctionType as ArbFunctionType, Value},
 };
-use arbutil::Color;
+use arbutil::{math::SaturatingSum, Color};
 use eyre::{bail, eyre, Report, Result, WrapErr};
 use fnv::FnvHashMap as HashMap;
 use std::fmt::Debug;
@@ -401,18 +401,47 @@ impl Module {
         debug: bool,
         gas: &mut u64,
     ) -> Result<(Self, StylusData)> {
-        // paid for by the 3 million gas charge in program.go
+        let us_to_gas = |us: u64| {
+            let fudge = 2;
+            let sync_rate = 1_000_000 / 2;
+            let speed = 7_000_000;
+            us.saturating_mul(fudge * speed) / sync_rate
+        };
+
+        macro_rules! pay {
+            ($us:expr) => {
+                let amount = us_to_gas($us);
+                if *gas < amount {
+                    *gas = 0;
+                    bail!("out of gas");
+                }
+                *gas -= amount;
+            };
+        }
+
+        // pay for wasm
+        let wasm_len = wasm.len() as u64;
+        pay!(wasm_len.saturating_mul(31_733 / 100_000));
+
         let compile = CompileConfig::version(version, debug);
         let (bin, stylus_data) =
             WasmBinary::parse_user(wasm, page_limit, &compile).wrap_err("failed to parse wasm")?;
 
-        // naively charge 11 million gas to do the rest.
-        // in the future we'll implement a proper compilation pricing mechanism.
-        if *gas < 11_000_000 {
-            *gas = 0;
-            bail!("out of gas");
-        }
-        *gas -= 11_000_000;
+        // pay for funcs
+        let funcs = bin.functions.len() as u64;
+        pay!(funcs.saturating_mul(17_263) / 100_000);
+
+        // pay for data
+        let data = bin.datas.iter().map(|x| x.data.len()).saturating_sum() as u64;
+        pay!(data.saturating_mul(17_376) / 100_000);
+
+        // pay for memory
+        let mem = bin.memories.first().map(|x| x.initial).unwrap_or_default();
+        pay!(mem.saturating_mul(2217));
+
+        // pay for code
+        let code = bin.codes.iter().map(|x| x.expr.len()).saturating_sum() as u64;
+        pay!(code.saturating_mul(535) / 1_000);
 
         let module = Self::from_user_binary(&bin, compile.debug.debug_funcs, Some(stylus_data))
             .wrap_err("failed to build user module")?;

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 use crate::evm_api::GoEvmApi;

--- a/arbitrator/stylus/src/lib.rs
+++ b/arbitrator/stylus/src/lib.rs
@@ -12,7 +12,7 @@ use arbutil::{
 };
 use eyre::ErrReport;
 use native::NativeInstance;
-use prover::programs::prelude::*;
+use prover::programs::{prelude::*, StylusData};
 use run::RunProgram;
 use std::{marker::PhantomData, mem};
 
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn stylus_activate(
     output: *mut RustBytes,
     asm_len: *mut usize,
     module_hash: *mut Bytes32,
-    footprint: *mut u16,
+    stylus_data: *mut StylusData,
     gas: *mut u64,
 ) -> UserOutcomeKind {
     let wasm = wasm.slice();
@@ -128,13 +128,13 @@ pub unsafe extern "C" fn stylus_activate(
     let module_hash = &mut *module_hash;
     let gas = &mut *gas;
 
-    let (asm, module, pages) = match native::activate(wasm, version, page_limit, debug, gas) {
+    let (asm, module, info) = match native::activate(wasm, version, page_limit, debug, gas) {
         Ok(val) => val,
         Err(err) => return output.write_err(err),
     };
     *asm_len = asm.len();
     *module_hash = module.hash();
-    *footprint = pages;
+    *stylus_data = info;
 
     let mut data = asm;
     data.extend(&*module.into_bytes());

--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -20,6 +20,7 @@ use prover::{
         meter::{STYLUS_INK_LEFT, STYLUS_INK_STATUS},
         prelude::*,
         start::STYLUS_START,
+        StylusData,
     },
 };
 use std::{
@@ -385,10 +386,10 @@ pub fn activate(
     page_limit: u16,
     debug: bool,
     gas: &mut u64,
-) -> Result<(Vec<u8>, ProverModule, u16)> {
+) -> Result<(Vec<u8>, ProverModule, StylusData)> {
     let compile = CompileConfig::version(version, debug);
-    let (module, footprint) = ProverModule::activate(wasm, version, page_limit, debug, gas)?;
+    let (module, stylus_data) = ProverModule::activate(wasm, version, page_limit, debug, gas)?;
 
     let asm = self::module(wasm, compile).expect("failed to generate stylus module");
-    Ok((asm, module, footprint))
+    Ok((asm, module, stylus_data))
 }

--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 use crate::{

--- a/arbitrator/stylus/tests/grow-and-call.wat
+++ b/arbitrator/stylus/tests/grow-and-call.wat
@@ -1,4 +1,4 @@
-;; Copyright 2023, Offchain Labs, Inc.
+;; Copyright 2023-2024, Offchain Labs, Inc.
 ;; For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 (module

--- a/arbitrator/stylus/tests/grow-and-call.wat
+++ b/arbitrator/stylus/tests/grow-and-call.wat
@@ -5,6 +5,7 @@
     (import "vm_hooks" "pay_for_memory_grow" (func (param i32)))
     (import "vm_hooks" "read_args"           (func $read_args     (param i32)))
     (import "vm_hooks" "write_result"        (func $write_result  (param i32 i32)))
+    (import "vm_hooks" "msg_value"           (func $msg_value     (param i32)))
     (import "vm_hooks" "call_contract"       (func $call_contract (param i32 i32 i32 i32 i64 i32) (result i32)))
     (import "console" "tee_i32"              (func $tee           (param i32) (result i32)))
     (func (export "user_entrypoint") (param $args_len i32) (result i32)
@@ -19,11 +20,15 @@
         memory.grow
         drop
 
+        ;; copy the message value
+        i32.const 0x1000
+        call $msg_value
+
         ;; static call target contract
         i32.const 1                                    ;; address
         i32.const 21                                   ;; calldata
         (i32.sub (local.get $args_len) (i32.const 21)) ;; calldata len
-        i32.const 0x1000                               ;; zero callvalue
+        i32.const 0x1000                               ;; callvalue
         i64.const -1                                   ;; all gas
         i32.const 0x2000                               ;; return_data_len ptr
         call $call_contract

--- a/arbitrator/wasm-libraries/forward/src/main.rs
+++ b/arbitrator/wasm-libraries/forward/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 use eyre::Result;
@@ -51,7 +51,12 @@ struct Opts {
 
 fn main() -> Result<()> {
     let opts = Opts::from_args();
-    let file = &mut File::options().create(true).write(true).open(opts.path)?;
+    let file = &mut File::options()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(opts.path)?;
+
     match opts.stub {
         true => forward_stub(file),
         false => forward(file),

--- a/arbitrator/wasm-libraries/user-host/src/link.rs
+++ b/arbitrator/wasm-libraries/user-host/src/link.rs
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn go__github_com_offchainlabs_nitro_arbos_programs_activa
     };
     wavm::caller_store64(gas, *gas_left);
     wavm::write_bytes32(module_hash, module.hash());
-    sp.write_u32(info.init_gas).write_u32(info.asm_size);
+    sp.write_u32(info.init_gas).write_u32(info.asm_estimate);
     sp.write_u16(info.footprint).skip_space();
     sp.write_nullptr();
 }

--- a/arbitrator/wasm-libraries/user-host/src/link.rs
+++ b/arbitrator/wasm-libraries/user-host/src/link.rs
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 use crate::{

--- a/arbos/activate_test.go
+++ b/arbos/activate_test.go
@@ -62,7 +62,7 @@ func TestActivationDataFee(t *testing.T) {
 
 	// ensure the chain made enough money
 	minimumTotal := arbmath.UintToBig(uint64(capacity))
-	minimumTotal = arbmath.BigMulByUint(minimumTotal, 140/10*1e9)
+	minimumTotal = arbmath.BigMulByUint(minimumTotal, 59/10*1e9)
 	colors.PrintBlue("total ", totalFees.String(), " ", minimumTotal.String())
 	assert(arbmath.BigGreaterThan(totalFees, minimumTotal))
 
@@ -101,6 +101,6 @@ func TestActivationDataFee(t *testing.T) {
 	}
 
 	// check random programs
-	colors.PrintBlue("random ", totalFees.String(), " ", minimumTotal.String())
+	colors.PrintBlue("rands ", totalFees.String(), " ", minimumTotal.String())
 	assert(arbmath.BigGreaterThan(totalFees, minimumTotal))
 }

--- a/arbos/activate_test.go
+++ b/arbos/activate_test.go
@@ -1,0 +1,106 @@
+// Copyright 2021-2024, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+
+package arbos
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/offchainlabs/nitro/arbos/arbosState"
+	"github.com/offchainlabs/nitro/arbos/programs"
+	"github.com/offchainlabs/nitro/util/arbmath"
+	"github.com/offchainlabs/nitro/util/colors"
+	"github.com/offchainlabs/nitro/util/testhelpers"
+)
+
+func TestActivationDataFee(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	state, _ := arbosState.NewArbosMemoryBackedArbOSState()
+	pricer := state.Programs().DataPricer()
+	time := uint64(time.Now().Unix())
+
+	assert := func(cond bool) {
+		t.Helper()
+		if !cond {
+			Fail(t, "assertion failed")
+		}
+	}
+
+	hour := uint64(60 * 60)
+	commonSize := uint32(5 * 1024 * 1024)
+
+	fee, _ := pricer.UpdateModel(0, time)
+	assert(fee.Uint64() == 0)
+
+	firstHourlyFee, _ := pricer.UpdateModel(commonSize, time)
+	assert(firstHourlyFee.Uint64() > 0)
+
+	capacity := uint32(programs.InitialHourlyBytes)
+	usage := uint32(0)
+	lastFee := common.Big0
+	totalFees := common.Big0
+	reset := func() {
+		capacity = uint32(programs.InitialHourlyBytes)
+		usage = uint32(0)
+		lastFee = common.Big0
+		totalFees = common.Big0
+	}
+
+	reset()
+	for usage < capacity {
+		bytes := uint32(5 * 1024 * 1024)
+		fee, _ := pricer.UpdateModel(bytes, time+hour)
+		assert(arbmath.BigGreaterThan(fee, lastFee))
+
+		totalFees = arbmath.BigAdd(totalFees, fee)
+		usage += bytes
+		lastFee = fee
+	}
+
+	// ensure the chain made enough money
+	minimumTotal := arbmath.UintToBig(uint64(capacity))
+	minimumTotal = arbmath.BigMulByUint(minimumTotal, 140/10*1e9)
+	colors.PrintBlue("total ", totalFees.String(), " ", minimumTotal.String())
+	assert(arbmath.BigGreaterThan(totalFees, minimumTotal))
+
+	// advance a bit past an hour to reset the pricer
+	fee, _ = pricer.UpdateModel(commonSize, time+2*hour+60)
+	assert(arbmath.BigEquals(fee, firstHourlyFee))
+
+	// buy all the capacity at once
+	fee, _ = pricer.UpdateModel(capacity, time+3*hour)
+	colors.PrintBlue("every ", fee.String(), " ", minimumTotal.String())
+	assert(arbmath.BigGreaterThan(fee, minimumTotal))
+
+	reset()
+	for usage < capacity {
+		bytes := uint32(10 * 1024)
+		fee, _ := pricer.UpdateModel(bytes, time+5*hour)
+		assert(arbmath.BigGreaterThanOrEqual(fee, lastFee))
+
+		totalFees = arbmath.BigAdd(totalFees, fee)
+		usage += bytes
+		lastFee = fee
+	}
+
+	// check small programs
+	colors.PrintBlue("small ", totalFees.String(), " ", minimumTotal.String())
+	assert(arbmath.BigGreaterThan(totalFees, minimumTotal))
+
+	reset()
+	for usage < capacity {
+		bytes := testhelpers.RandomUint32(1, 1024*1024)
+		fee, _ := pricer.UpdateModel(bytes, time+7*hour)
+
+		totalFees = arbmath.BigAdd(totalFees, fee)
+		usage += bytes
+		lastFee = fee
+	}
+
+	// check random programs
+	colors.PrintBlue("random ", totalFees.String(), " ", minimumTotal.String())
+	assert(arbmath.BigGreaterThan(totalFees, minimumTotal))
+}

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -418,7 +418,7 @@ func ProduceBlockAdvanced(
 
 		// Add gas used since startup to prometheus metric.
 		gasUsed := arbmath.SaturatingUSub(receipt.GasUsed, receipt.GasUsedForL1)
-		gasUsedSinceStartupCounter.Inc(arbmath.SaturatingCast(gasUsed))
+		gasUsedSinceStartupCounter.Inc(arbmath.SaturatingCast[int64](gasUsed))
 
 		complete = append(complete, tx)
 		receipts = append(receipts, receipt)

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package arbos

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -104,7 +104,7 @@ func ApplyInternalTxUpdate(tx *types.ArbitrumInternalTx, state *arbosState.Arbos
 		if err != nil {
 			log.Warn("L1Pricing PerBatchGas failed", "err", err)
 		}
-		gasSpent := arbmath.SaturatingAdd(perBatchGas, arbmath.SaturatingCast(batchDataGas))
+		gasSpent := arbmath.SaturatingAdd(perBatchGas, arbmath.SaturatingCast[int64](batchDataGas))
 		weiSpent := arbmath.BigMulByUint(l1BaseFeeWei, arbmath.SaturatingUCast[uint64](gasSpent))
 		err = l1p.UpdateForBatchPosterSpending(
 			evm.StateDB,

--- a/arbos/internal_tx.go
+++ b/arbos/internal_tx.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package arbos

--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -46,7 +46,7 @@ func (ps *L2PricingState) UpdatePricingModel(l2BaseFee *big.Int, timePassed uint
 	if backlog > tolerance*speedLimit {
 		excess := int64(backlog - tolerance*speedLimit)
 		exponentBips := arbmath.NaturalToBips(excess) / arbmath.Bips(inertia*speedLimit)
-		baseFee = arbmath.BigMulByBips(minBaseFee, arbmath.ApproxExpBasisPoints(exponentBips))
+		baseFee = arbmath.BigMulByBips(minBaseFee, arbmath.ApproxExpBasisPoints(exponentBips, 4))
 	}
 	_ = ps.SetBaseFeeWei(baseFee)
 }

--- a/arbos/l2pricing/model.go
+++ b/arbos/l2pricing/model.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package l2pricing

--- a/arbos/programs/data_pricer.go
+++ b/arbos/programs/data_pricer.go
@@ -1,0 +1,70 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+package programs
+
+import (
+	"math/big"
+
+	"github.com/offchainlabs/nitro/arbos/storage"
+	"github.com/offchainlabs/nitro/util/arbmath"
+)
+
+type dataPricer struct {
+	backingStorage     *storage.Storage
+	poolBytes          storage.StorageBackedInt64
+	poolBytesPerSecond storage.StorageBackedInt64
+	maxPoolBytes       storage.StorageBackedInt64
+	lastUpdateTime     storage.StorageBackedUint64
+	minPrice           storage.StorageBackedUint32
+	inertia            storage.StorageBackedUint64
+}
+
+const initialPoolBytes = initialMaxPoolBytes
+const initialPoolBytesPerSecond = initialMaxPoolBytes / (60 * 60) // refill each hour
+const initialMaxPoolBytes = 4 * (1 << 40) / (365 * 24)            // 4Tb total footprint
+const initialLastUpdateTime = 1421388000                          // the day it all began
+const initialMinPrice = 10                                        // one USD
+const initialInertia = 70832408                                   // expensive at 4Tb
+
+func openDataPricer(sto *storage.Storage) *dataPricer {
+	return &dataPricer{
+		backingStorage:     sto,
+		poolBytes:          sto.OpenStorageBackedInt64(initialPoolBytes),
+		poolBytesPerSecond: sto.OpenStorageBackedInt64(initialPoolBytesPerSecond),
+		maxPoolBytes:       sto.OpenStorageBackedInt64(initialMaxPoolBytes),
+		lastUpdateTime:     sto.OpenStorageBackedUint64(initialLastUpdateTime),
+		minPrice:           sto.OpenStorageBackedUint32(initialMinPrice),
+		inertia:            sto.OpenStorageBackedUint64(initialInertia),
+	}
+}
+
+func (p *dataPricer) updateModel(tempBytes int64, time uint64) (*big.Int, error) {
+	poolBytes, _ := p.poolBytes.Get()
+	poolBytesPerSecond, _ := p.poolBytesPerSecond.Get()
+	maxPoolBytes, _ := p.maxPoolBytes.Get()
+	lastUpdateTime, _ := p.lastUpdateTime.Get()
+	minPrice, _ := p.minPrice.Get()
+	inertia, err := p.inertia.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	timeDelta := arbmath.SaturatingCast(time - lastUpdateTime)
+	credit := arbmath.SaturatingMul(poolBytesPerSecond, timeDelta)
+	poolBytes = arbmath.MinInt(arbmath.SaturatingAdd(poolBytes, credit), maxPoolBytes)
+	poolBytes = arbmath.SaturatingSub(poolBytes, tempBytes)
+
+	if err := p.poolBytes.Set(poolBytes); err != nil {
+		return nil, err
+	}
+
+	cost := big.NewInt(arbmath.SaturatingMul(int64(minPrice), tempBytes))
+
+	if poolBytes < 0 {
+		excess := arbmath.SaturatingNeg(poolBytes)
+		exponent := arbmath.NaturalToBips(excess) / arbmath.Bips(inertia)
+		cost = arbmath.BigMulByBips(cost, arbmath.ApproxExpBasisPoints(exponent, 12))
+	}
+	return cost, nil
+}

--- a/arbos/programs/data_pricer.go
+++ b/arbos/programs/data_pricer.go
@@ -28,11 +28,11 @@ const (
 )
 
 const initialDemand = 0                                      // no demand
-const InitialHourlyBytes = 4 * (1 << 40) / (365 * 24)        // 4Tb total footprint
+const InitialHourlyBytes = 1 * (1 << 40) / (365 * 24)        // 1Tb total footprint
 const initialBytesPerSecond = InitialHourlyBytes / (60 * 60) // refill each second
 const initialLastUpdateTime = 1421388000                     // the day it all began
 const initialMinPrice = 82928201                             // 5Mb = $1
-const initialInertia = 70177364                              // expensive at 4Tb
+const initialInertia = 21360419                              // expensive at 1Tb
 
 func initDataPricer(sto *storage.Storage) {
 	demand := sto.OpenStorageBackedUint32(demandOffset)

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 //go:build !js

--- a/arbos/programs/native.go
+++ b/arbos/programs/native.go
@@ -86,10 +86,10 @@ func activateProgram(
 	module := data[split:]
 
 	info := &activationInfo{
-		moduleHash: hash,
-		initGas:    uint32(stylusData.init_gas),
-		asmSize:    uint32(stylusData.asm_size),
-		footprint:  uint16(stylusData.footprint),
+		moduleHash:  hash,
+		initGas:     uint32(stylusData.init_gas),
+		asmEstimate: uint32(stylusData.asm_estimate),
+		footprint:   uint16(stylusData.footprint),
 	}
 	db.ActivateWasm(hash, asm, module)
 	return info, err

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -414,7 +414,7 @@ func (p Programs) ProgramKeepalive(codeHash common.Hash, time uint64) (*big.Int,
 		return nil, ProgramNeedsUpgradeError(program.version, stylusVersion)
 	}
 
-	naive := int64(5 * 1024 * 1024)
+	naive := uint32(5 * 1024 * 1024)
 	cost, err := p.dataPricer.updateModel(naive, time)
 	if err != nil {
 		return nil, err

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -398,7 +398,7 @@ func (p Programs) getProgram(codeHash common.Hash, time uint64) (Program, error)
 func (p Programs) setProgram(codehash common.Hash, program Program) error {
 	data := common.Hash{}
 	copy(data[0:], arbmath.Uint16ToBytes(program.version))
-	copy(data[3:], arbmath.Uint24ToBytes(program.initGas))
+	copy(data[2:], arbmath.Uint24ToBytes(program.initGas))
 	copy(data[5:], arbmath.Uint24ToBytes(program.asmEstimate))
 	copy(data[8:], arbmath.Uint16ToBytes(program.footprint))
 	copy(data[10:], arbmath.UintToBytes(program.activatedAt))

--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -24,7 +24,7 @@ type Programs struct {
 	backingStorage *storage.Storage
 	programs       *storage.Storage
 	moduleHashes   *storage.Storage
-	dataPricer     *dataPricer
+	dataPricer     *DataPricer
 	inkPrice       storage.StorageBackedUint24
 	maxStackDepth  storage.StorageBackedUint32
 	freePages      storage.StorageBackedUint16
@@ -207,6 +207,10 @@ func (p Programs) SetKeepaliveDays(days uint16) error {
 	return p.keepaliveDays.Set(days)
 }
 
+func (p Programs) DataPricer() *DataPricer {
+	return p.dataPricer
+}
+
 func (p Programs) ActivateProgram(evm *vm.EVM, address common.Address, debugMode bool) (
 	uint16, common.Hash, common.Hash, *big.Int, bool, error,
 ) {
@@ -255,7 +259,7 @@ func (p Programs) ActivateProgram(evm *vm.EVM, address common.Address, debugMode
 		return 0, codeHash, common.Hash{}, nil, true, err
 	}
 
-	dataFee, err := p.dataPricer.updateModel(info.asmEstimate, evm.Context.Time)
+	dataFee, err := p.dataPricer.UpdateModel(info.asmEstimate, evm.Context.Time)
 	if err != nil {
 		return 0, codeHash, common.Hash{}, nil, true, err
 	}
@@ -431,7 +435,7 @@ func (p Programs) ProgramKeepalive(codeHash common.Hash, time uint64) (*big.Int,
 		return nil, ProgramNeedsUpgradeError(program.version, stylusVersion)
 	}
 
-	cost, err := p.dataPricer.updateModel(program.asmEstimate.ToUint32(), time)
+	cost, err := p.dataPricer.UpdateModel(program.asmEstimate.ToUint32(), time)
 	if err != nil {
 		return nil, err
 	}

--- a/arbos/programs/wasm.go
+++ b/arbos/programs/wasm.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 //go:build js

--- a/arbos/programs/wasm.go
+++ b/arbos/programs/wasm.go
@@ -33,7 +33,7 @@ type rustEvmData byte
 
 func activateProgramRustImpl(
 	wasm []byte, pageLimit, version u16, debugMode u32, moduleHash *hash, gas *u64,
-) (footprint u16, err *rustVec)
+) (initGas, asmSize u32, footprint u16, err *rustVec)
 
 func callProgramRustImpl(
 	moduleHash *hash, calldata []byte, params *rustConfig, evmApi uint32, evmData *rustEvmData, gas *u64,
@@ -66,17 +66,19 @@ func activateProgram(
 	version u16,
 	debug bool,
 	burner burn.Burner,
-) (common.Hash, u16, error) {
+) (*activationInfo, error) {
 	debugMode := arbmath.BoolToUint32(debug)
 	moduleHash := common.Hash{}
 	gasPtr := burner.GasLeft()
 
-	footprint, err := activateProgramRustImpl(wasm, pageLimit, version, debugMode, &moduleHash, gasPtr)
+	initGas, asmSize, footprint, err := activateProgramRustImpl(
+		wasm, pageLimit, version, debugMode, &moduleHash, gasPtr,
+	)
 	if err != nil {
 		_, _, err := userFailure.toResult(err.intoSlice(), debug)
-		return moduleHash, footprint, err
+		return nil, err
 	}
-	return moduleHash, footprint, nil
+	return &activationInfo{moduleHash, initGas, asmSize, footprint}, nil
 }
 
 func callProgram(

--- a/arbos/programs/wasm.go
+++ b/arbos/programs/wasm.go
@@ -33,7 +33,7 @@ type rustEvmData byte
 
 func activateProgramRustImpl(
 	wasm []byte, pageLimit, version u16, debugMode u32, moduleHash *hash, gas *u64,
-) (initGas, asmSize u32, footprint u16, err *rustVec)
+) (initGas, asmEstimate u32, footprint u16, err *rustVec)
 
 func callProgramRustImpl(
 	moduleHash *hash, calldata []byte, params *rustConfig, evmApi uint32, evmData *rustEvmData, gas *u64,
@@ -71,14 +71,14 @@ func activateProgram(
 	moduleHash := common.Hash{}
 	gasPtr := burner.GasLeft()
 
-	initGas, asmSize, footprint, err := activateProgramRustImpl(
+	initGas, asmEstimate, footprint, err := activateProgramRustImpl(
 		wasm, pageLimit, version, debugMode, &moduleHash, gasPtr,
 	)
 	if err != nil {
 		_, _, err := userFailure.toResult(err.intoSlice(), debug)
 		return nil, err
 	}
-	return &activationInfo{moduleHash, initGas, asmSize, footprint}, nil
+	return &activationInfo{moduleHash, initGas, asmEstimate, footprint}, nil
 }
 
 func callProgram(

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package arbos

--- a/arbos/tx_processor.go
+++ b/arbos/tx_processor.go
@@ -568,7 +568,7 @@ func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 			}
 		}
 		// we've already credited the network fee account, but we didn't charge the gas pool yet
-		p.state.Restrict(p.state.L2PricingState().AddToGasPool(-arbmath.SaturatingCast(gasUsed)))
+		p.state.Restrict(p.state.L2PricingState().AddToGasPool(-arbmath.SaturatingCast[int64](gasUsed)))
 		return
 	}
 
@@ -626,7 +626,7 @@ func (p *TxProcessor) EndTxHook(gasLeft uint64, success bool) {
 			log.Error("total gas used < poster gas component", "gasUsed", gasUsed, "posterGas", p.posterGas)
 			computeGas = gasUsed
 		}
-		p.state.Restrict(p.state.L2PricingState().AddToGasPool(-arbmath.SaturatingCast(computeGas)))
+		p.state.Restrict(p.state.L2PricingState().AddToGasPool(-arbmath.SaturatingCast[int64](computeGas)))
 	}
 }
 

--- a/arbos/util/util.go
+++ b/arbos/util/util.go
@@ -196,7 +196,7 @@ func UintToHash(val uint64) common.Hash {
 }
 
 func HashPlusInt(x common.Hash, y int64) common.Hash {
-	return common.BigToHash(new(big.Int).Add(x.Big(), big.NewInt(y))) //BUGBUG: BigToHash(x) converts abs(x) to a Hash
+	return common.BigToHash(new(big.Int).Add(x.Big(), big.NewInt(y))) // BUGBUG: BigToHash(x) converts abs(x) to a Hash
 }
 
 func RemapL1Address(l1Addr common.Address) common.Address {

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -192,9 +192,9 @@ func (con ArbOwner) SetWasmPageLimit(c ctx, evm mech, limit uint16) error {
 	return c.State.Programs().SetPageLimit(limit)
 }
 
-// Sets the added wasm call cost based on binary size
-func (con ArbOwner) SetWasmCallScalar(c ctx, _ mech, gas uint16) error {
-	return c.State.Programs().SetCallScalar(gas)
+// Sets the minimum cost to invoke a program
+func (con ArbOwner) SetWasmMinInitGas(c ctx, _ mech, gas uint16) error {
+	return c.State.Programs().SetMinInitGas(gas)
 }
 
 // Sets the number of days after which programs deactivate

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package precompiles
@@ -192,9 +192,19 @@ func (con ArbOwner) SetWasmPageLimit(c ctx, evm mech, limit uint16) error {
 	return c.State.Programs().SetPageLimit(limit)
 }
 
-// SetWasmCallScalar sets the added wasm call cost based on binary size
+// Sets the added wasm call cost based on binary size
 func (con ArbOwner) SetWasmCallScalar(c ctx, _ mech, gas uint16) error {
 	return c.State.Programs().SetCallScalar(gas)
+}
+
+// Sets the number of days after which programs deactivate
+func (con ArbOwner) SetWasmExpiryDays(c ctx, _ mech, days uint16) error {
+	return c.State.Programs().SetExpiryDays(days)
+}
+
+// Sets the age a program must be to perform a keepalive
+func (con ArbOwner) SetWasmKeepaliveDays(c ctx, _ mech, days uint16) error {
+	return c.State.Programs().SetExpiryDays(days)
 }
 
 func (con ArbOwner) SetChainConfig(c ctx, evm mech, serializedChainConfig []byte) error {

--- a/precompiles/ArbRetryableTx.go
+++ b/precompiles/ArbRetryableTx.go
@@ -127,7 +127,7 @@ func (con ArbRetryableTx) Redeem(c ctx, evm mech, ticketId bytes32) (bytes32, er
 
 	// Add the gasToDonate back to the gas pool: the retryable attempt will then consume it.
 	// This ensures that the gas pool has enough gas to run the retryable attempt.
-	return retryTxHash, c.State.L2PricingState().AddToGasPool(arbmath.SaturatingCast(gasToDonate))
+	return retryTxHash, c.State.L2PricingState().AddToGasPool(arbmath.SaturatingCast[int64](gasToDonate))
 }
 
 // GetLifetime gets the default lifetime period a retryable has at creation

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -25,8 +25,8 @@ type ArbWasm struct {
 func (con ArbWasm) ActivateProgram(c ctx, evm mech, value huge, program addr) (uint16, error) {
 	debug := evm.ChainConfig().DebugMode()
 
-	// charge 3 million up front to begin activation
-	if err := c.Burn(3000000); err != nil {
+	// charge a fixed cost up front to begin activation
+	if err := c.Burn(1659168); err != nil {
 		return 0, err
 	}
 	version, codeHash, moduleHash, takeAllGas, err := c.State.Programs().ActivateProgram(evm, program, debug)

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -106,13 +106,13 @@ func (con ArbWasm) ProgramVersion(c ctx, evm mech, program addr) (uint16, error)
 	return con.CodehashVersion(c, evm, codehash)
 }
 
-// Gets the uncompressed size of program at addr
-func (con ArbWasm) ProgramSize(c ctx, evm mech, program addr) (uint32, error) {
+// Gets the cost to invoke the program (not including MinInitGas)
+func (con ArbWasm) ProgramInitGas(c ctx, evm mech, program addr) (uint32, error) {
 	codehash, err := c.GetCodeHash(program)
 	if err != nil {
 		return 0, err
 	}
-	return c.State.Programs().ProgramSize(codehash, evm.Context.Time)
+	return c.State.Programs().ProgramInitGas(codehash, evm.Context.Time)
 }
 
 // Gets the footprint of program at addr
@@ -133,9 +133,9 @@ func (con ArbWasm) ProgramTimeLeft(c ctx, evm mech, program addr) (uint64, error
 	return c.State.Programs().ProgramTimeLeft(codehash, evm.Context.Time)
 }
 
-// Gets the added wasm call cost paid per half kb uncompressed wasm
-func (con ArbWasm) CallScalar(c ctx, _ mech) (uint16, error) {
-	return c.State.Programs().CallScalar()
+// Gets the minimum cost to invoke a program
+func (con ArbWasm) MinInitGas(c ctx, _ mech) (uint16, error) {
+	return c.State.Programs().MinInitGas()
 }
 
 // Gets the number of days after which programs deactivate

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package precompiles
@@ -74,7 +74,7 @@ func (con ArbWasm) CodehashVersion(c ctx, evm mech, codehash bytes32) (uint16, e
 	return c.State.Programs().CodehashVersion(codehash, evm.Context.Time)
 }
 
-// @notice extends a program's lifetime (reverts if too soon)
+// @notice extends a program's expiration date (reverts if too soon)
 func (con ArbWasm) CodehashKeepalive(c ctx, evm mech, codehash bytes32) error {
 	return c.State.Programs().ProgramKeepalive(codehash, evm.Context.Time)
 }
@@ -125,7 +125,7 @@ func (con ArbWasm) ExpiryDays(c ctx, _ mech) (uint16, error) {
 	return c.State.Programs().ExpiryDays()
 }
 
-// Gets the number of days after which programs deactivate
+// Gets the age a program must be to perform a keepalive
 func (con ArbWasm) KeepaliveDays(c ctx, _ mech) (uint16, error) {
 	return c.State.Programs().KeepaliveDays()
 }

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -76,7 +76,12 @@ func (con ArbWasm) CodehashVersion(c ctx, evm mech, codehash bytes32) (uint16, e
 
 // @notice extends a program's expiration date (reverts if too soon)
 func (con ArbWasm) CodehashKeepalive(c ctx, evm mech, codehash bytes32) error {
-	return c.State.Programs().ProgramKeepalive(codehash, evm.Context.Time)
+	cost, err := c.State.Programs().ProgramKeepalive(codehash, evm.Context.Time)
+	if err != nil {
+		return err
+	}
+	_ = cost // consume value
+	return nil
 }
 
 // Gets the stylus version that program at addr was most recently compiled with

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 package precompiles
@@ -558,7 +558,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 
 	ArbWasmImpl := &ArbWasm{Address: types.ArbWasmAddress}
 	ArbWasm := insert(MakePrecompile(templates.ArbWasmMetaData, ArbWasmImpl))
-	ArbWasm.arbosVersion = 10
+	ArbWasm.arbosVersion = 11
 	programs.ProgramNotActivatedError = ArbWasmImpl.ProgramNotActivatedError
 	programs.ProgramNeedsUpgradeError = ArbWasmImpl.ProgramNeedsUpgradeError
 	programs.ProgramExpiredError = ArbWasmImpl.ProgramExpiredError

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -560,8 +560,10 @@ func Precompiles() map[addr]ArbosPrecompile {
 	ArbWasm := insert(MakePrecompile(templates.ArbWasmMetaData, ArbWasmImpl))
 	ArbWasm.arbosVersion = 10
 	programs.ProgramNotActivatedError = ArbWasmImpl.ProgramNotActivatedError
-	programs.ProgramOutOfDateError = ArbWasmImpl.ProgramOutOfDateError
+	programs.ProgramNeedsUpgradeError = ArbWasmImpl.ProgramNeedsUpgradeError
+	programs.ProgramExpiredError = ArbWasmImpl.ProgramExpiredError
 	programs.ProgramUpToDateError = ArbWasmImpl.ProgramUpToDateError
+	programs.ProgramKeepaliveTooSoon = ArbWasmImpl.ProgramKeepaliveTooSoonError
 
 	ArbRetryableImpl := &ArbRetryableTx{Address: types.ArbRetryableTxAddress}
 	ArbRetryable := insert(MakePrecompile(templates.ArbRetryableTxMetaData, ArbRetryableImpl))

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -887,7 +887,10 @@ func testMemory(t *testing.T, jit bool) {
 	// check that activation then succeeds
 	args[0] = 0x00
 	tx = l2info.PrepareTxTo("Owner", &growCallAddr, 1e9, oneEth, args)
-	ensure(tx, l2client.SendTransaction(ctx, tx)) // TODO: check receipt after compilation pricing
+	receipt = ensure(tx, l2client.SendTransaction(ctx, tx))
+	if receipt.GasUsedForL2() < 1659168 {
+		Fatal(t, "activation unexpectedly cheap")
+	}
 
 	// check footprint can induce a revert
 	args = arbmath.ConcatByteSlices([]byte{122}, growCallAddr[:], []byte{0}, common.Address{}.Bytes())

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1119,22 +1119,11 @@ func deployWasm(
 	t *testing.T, ctx context.Context, auth bind.TransactOpts, l2client *ethclient.Client, file string,
 ) common.Address {
 	name := strings.TrimSuffix(filepath.Base(file), filepath.Ext(file))
-	wasm, uncompressed := readWasmFile(t, file)
+	wasm, _ := readWasmFile(t, file)
 	auth.GasLimit = 32000000 // skip gas estimation
 	program := deployContract(t, ctx, auth, l2client, wasm)
 	colors.PrintGrey(name, ": deployed to ", program.Hex())
 	activateWasm(t, ctx, auth, l2client, program, name)
-
-	// check that program size matches
-	arbWasm, err := precompilesgen.NewArbWasm(types.ArbWasmAddress, l2client)
-	Require(t, err)
-	programSize, err := arbWasm.ProgramSize(nil, program)
-	Require(t, err)
-	expected := (len(uncompressed) + 511) / 512 * 512
-	if int(programSize) != expected {
-		Fatal(t, "unexpected program size", name, programSize, expected, len(wasm))
-	}
-
 	return program
 }
 

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -884,7 +884,7 @@ func testMemory(t *testing.T, jit bool) {
 	args = arbmath.ConcatByteSlices([]byte{60}, types.ArbWasmAddress[:], pack(activate(growHugeAddr)))
 	expectFailure(growCallAddr, args, oneEth) // consumes 64, then tries to compile something 120
 
-	// check that arctivation then succeeds
+	// check that activation then succeeds
 	args[0] = 0x00
 	tx = l2info.PrepareTxTo("Owner", &growCallAddr, 1e9, oneEth, args)
 	ensure(tx, l2client.SendTransaction(ctx, tx)) // TODO: check receipt after compilation pricing

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, Offchain Labs, Inc.
+// Copyright 2022-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 package arbtest

--- a/util/arbmath/bips.go
+++ b/util/arbmath/bips.go
@@ -36,9 +36,13 @@ func UintMulByBips(value uint64, bips Bips) uint64 {
 }
 
 func SaturatingCastToBips(value uint64) Bips {
-	return Bips(SaturatingCast(value))
+	return Bips(SaturatingCast[int64](value))
 }
 
 func (bips UBips) Uint64() uint64 {
+	return uint64(bips)
+}
+
+func (bips Bips) Uint64() uint64 {
 	return uint64(bips)
 }

--- a/util/arbmath/bips.go
+++ b/util/arbmath/bips.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package arbmath

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -320,9 +320,11 @@ func SaturatingMul[T Signed](a, b T) T {
 // SaturatingCast cast an unsigned integer to a signed one, clipping to [0, S::MAX]
 func SaturatingCast[S Signed, T Unsigned](value T) S {
 	tBig := unsafe.Sizeof(T(0)) >= unsafe.Sizeof(S(0))
-	sMax := T(1<<(8*unsafe.Sizeof(S(0)))-1) >> 1
-	if tBig && value > sMax {
-		return S(sMax)
+	if tBig {
+		sMax := T(1<<(8*unsafe.Sizeof(S(0)))-1) >> 1
+		if value > sMax {
+			return S(sMax)
+		}
 	}
 	return S(value)
 }

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -320,8 +320,9 @@ func SaturatingMul[T Signed](a, b T) T {
 // SaturatingCast cast an unsigned integer to a signed one, clipping to [0, S::MAX]
 func SaturatingCast[S Signed, T Unsigned](value T) S {
 	tBig := unsafe.Sizeof(T(0)) >= unsafe.Sizeof(S(0))
-	if tBig && value > T(^S(0)>>1) {
-		return ^S(0) >> 1
+	sMax := T(1<<(8*unsafe.Sizeof(S(0)))-1) >> 1
+	if tBig && value > sMax {
+		return S(sMax)
 	}
 	return S(value)
 }

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -320,7 +320,7 @@ func SaturatingMul[T Signed](a, b T) T {
 // SaturatingCast cast an unsigned integer to a signed one, clipping to [0, S::MAX]
 func SaturatingCast[S Signed, T Unsigned](value T) S {
 	tBig := unsafe.Sizeof(T(0)) >= unsafe.Sizeof(S(0))
-	bits := 8 * unsafe.Sizeof(S(0))
+	bits := uint64(8 * unsafe.Sizeof(S(0)))
 	sMax := T(1<<bits-1) >> 1
 	if tBig && value > sMax {
 		return S(sMax)

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 package arbmath

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -320,11 +320,10 @@ func SaturatingMul[T Signed](a, b T) T {
 // SaturatingCast cast an unsigned integer to a signed one, clipping to [0, S::MAX]
 func SaturatingCast[S Signed, T Unsigned](value T) S {
 	tBig := unsafe.Sizeof(T(0)) >= unsafe.Sizeof(S(0))
-	if tBig {
-		sMax := T(1<<(8*unsafe.Sizeof(S(0)))-1) >> 1
-		if value > sMax {
-			return S(sMax)
-		}
+	bits := 8 * unsafe.Sizeof(S(0))
+	sMax := T(1<<bits-1) >> 1
+	if tBig && value > sMax {
+		return S(sMax)
 	}
 	return S(value)
 }

--- a/util/arbmath/math_test.go
+++ b/util/arbmath/math_test.go
@@ -78,16 +78,16 @@ func TestMath(t *testing.T) {
 	assert(uint(math.MaxInt-1) == SaturatingUCast[uint](math.MaxInt-1))
 	assert(uint(math.MaxInt-1) == SaturatingUCast[uint](int64(math.MaxInt-1)))
 
-	assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64))
-	assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64-1))
+	//assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64))
+	//assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64-1))
 	assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64))
-	assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64-1))
-	assert(int8(math.MaxInt8) == SaturatingCast[int8, uint16](math.MaxUint16))
-	assert(int8(32) == SaturatingCast[int8, uint16](32))
+	//assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64-1))
+	//assert(int8(math.MaxInt8) == SaturatingCast[int8, uint16](math.MaxUint16))
+	/*assert(int8(32) == SaturatingCast[int8, uint16](32))
 	assert(int16(0) == SaturatingCast[int16, uint32](0))
 	assert(int16(math.MaxInt16) == SaturatingCast[int16, uint32](math.MaxInt16))
 	assert(int16(math.MaxInt16) == SaturatingCast[int16, uint16](math.MaxInt16))
-	assert(int16(math.MaxInt8) == SaturatingCast[int16, uint8](math.MaxInt8))
+	assert(int16(math.MaxInt8) == SaturatingCast[int16, uint8](math.MaxInt8))*/
 
 	assert(uint32(math.MaxUint32) == SaturatingUUCast[uint32, uint64](math.MaxUint64))
 	assert(uint32(math.MaxUint16) == SaturatingUUCast[uint32, uint64](math.MaxUint16))

--- a/util/arbmath/math_test.go
+++ b/util/arbmath/math_test.go
@@ -78,16 +78,16 @@ func TestMath(t *testing.T) {
 	assert(uint(math.MaxInt-1) == SaturatingUCast[uint](math.MaxInt-1))
 	assert(uint(math.MaxInt-1) == SaturatingUCast[uint](int64(math.MaxInt-1)))
 
-	//assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64))
-	//assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64-1))
+	assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64))
+	assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64-1))
 	assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64))
-	//assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64-1))
-	//assert(int8(math.MaxInt8) == SaturatingCast[int8, uint16](math.MaxUint16))
-	/*assert(int8(32) == SaturatingCast[int8, uint16](32))
+	assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64-1))
+	assert(int8(math.MaxInt8) == SaturatingCast[int8, uint16](math.MaxUint16))
+	assert(int8(32) == SaturatingCast[int8, uint16](32))
 	assert(int16(0) == SaturatingCast[int16, uint32](0))
 	assert(int16(math.MaxInt16) == SaturatingCast[int16, uint32](math.MaxInt16))
 	assert(int16(math.MaxInt16) == SaturatingCast[int16, uint16](math.MaxInt16))
-	assert(int16(math.MaxInt8) == SaturatingCast[int16, uint8](math.MaxInt8))*/
+	assert(int16(math.MaxInt8) == SaturatingCast[int16, uint8](math.MaxInt8))
 
 	assert(uint32(math.MaxUint32) == SaturatingUUCast[uint32, uint64](math.MaxUint64))
 	assert(uint32(math.MaxUint16) == SaturatingUUCast[uint32, uint64](math.MaxUint16))

--- a/util/arbmath/math_test.go
+++ b/util/arbmath/math_test.go
@@ -77,6 +77,22 @@ func TestMath(t *testing.T) {
 	assert(uint8(math.MaxUint8) == SaturatingUCast[uint8](math.MaxInt-1))
 	assert(uint(math.MaxInt-1) == SaturatingUCast[uint](math.MaxInt-1))
 	assert(uint(math.MaxInt-1) == SaturatingUCast[uint](int64(math.MaxInt-1)))
+
+	assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64))
+	assert(int64(math.MaxInt64) == SaturatingCast[int64, uint64](math.MaxUint64-1))
+	assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64))
+	assert(int32(math.MaxInt32) == SaturatingCast[int32, uint64](math.MaxUint64-1))
+	assert(int8(math.MaxInt8) == SaturatingCast[int8, uint16](math.MaxUint16))
+	assert(int8(32) == SaturatingCast[int8, uint16](32))
+	assert(int16(0) == SaturatingCast[int16, uint32](0))
+	assert(int16(math.MaxInt16) == SaturatingCast[int16, uint32](math.MaxInt16))
+	assert(int16(math.MaxInt16) == SaturatingCast[int16, uint16](math.MaxInt16))
+	assert(int16(math.MaxInt8) == SaturatingCast[int16, uint8](math.MaxInt8))
+
+	assert(uint32(math.MaxUint32) == SaturatingUUCast[uint32, uint64](math.MaxUint64))
+	assert(uint32(math.MaxUint16) == SaturatingUUCast[uint32, uint64](math.MaxUint16))
+	assert(uint32(math.MaxUint16) == SaturatingUUCast[uint32, uint16](math.MaxUint16))
+	assert(uint16(math.MaxUint16) == SaturatingUUCast[uint16, uint16](math.MaxUint16))
 }
 
 func Fail(t *testing.T, printables ...interface{}) {

--- a/util/arbmath/math_test.go
+++ b/util/arbmath/math_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, Offchain Labs, Inc.
+// Copyright 2021-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 package arbmath

--- a/util/arbmath/time.go
+++ b/util/arbmath/time.go
@@ -1,0 +1,8 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+package arbmath
+
+func DaysToSeconds[T Unsigned](days T) uint64 {
+	return uint64(days) * 24 * 60 * 60
+}

--- a/util/arbmath/uint24.go
+++ b/util/arbmath/uint24.go
@@ -4,6 +4,7 @@
 package arbmath
 
 import (
+	"encoding/binary"
 	"errors"
 	"math/big"
 )
@@ -36,4 +37,17 @@ func BigToUint24OrPanic(value *big.Int) Uint24 {
 		panic("big.Int value exceeds the max Uint24")
 	}
 	return Uint24(value.Uint64())
+}
+
+// creates a uint24 from its big-endian representation
+func BytesToUint24(value []byte) Uint24 {
+	value32 := ConcatByteSlices([]byte{0}, value)
+	return Uint24(binary.BigEndian.Uint32(value32))
+}
+
+// casts a uint24 to its big-endian representation
+func Uint24ToBytes(value Uint24) []byte {
+	result := make([]byte, 4)
+	binary.BigEndian.PutUint32(result, value.ToUint32())
+	return result[1:]
 }

--- a/util/arbmath/uint24.go
+++ b/util/arbmath/uint24.go
@@ -1,4 +1,4 @@
-// Copyright 2023, Offchain Labs, Inc.
+// Copyright 2023-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 package arbmath


### PR DESCRIPTION
This PR introduces activation pricing, the final component of the Stylus VM.

Previously, activation cost a flat 14 million gas, regardless of the WASM being processed. This PR introduces a more sophisticated pricing policy that cuts fees the more well behaved a WASM is. For example, typical programs like ERC-20 contracts cost 2-3 million gas per activation.

Included is the full lifecycle for a program. After a year, the program expires, unless the user re-activates or calls `ArbWasm`'s new `keepalive` method. Additional precompile methods exist to introspect programs and the pricer.

Program activation also now requires paying a data fee, which starts at about $1 and grows exponentially with demand. This allows the chain to charge less for activations in typical scenarios, ramping up only when resources are consumed too quickly. Importantly, data fees are charged in wei, not gas, which means storage doesn't become more expensive just because compute might.

Associated PRs
- https://github.com/OffchainLabs/stylus-contracts/pull/28