### PR TITLE
Fix keepalive days

### DIFF
--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -95,7 +95,7 @@ impl<E: EvmApi> NativeInstance<E> {
     ) -> Result<Self> {
         let env = WasmEnv::new(compile, None, evm, evm_data);
         let store = env.compile.store();
-        let module = Module::deserialize(&store, module)?;
+        let module = unsafe { Module::deserialize_unchecked(&store, module)? };
         Self::from_module(module, store, env)
     }
 

--- a/precompiles/ArbOwner.go
+++ b/precompiles/ArbOwner.go
@@ -204,7 +204,7 @@ func (con ArbOwner) SetWasmExpiryDays(c ctx, _ mech, days uint16) error {
 
 // Sets the age a program must be to perform a keepalive
 func (con ArbOwner) SetWasmKeepaliveDays(c ctx, _ mech, days uint16) error {
-	return c.State.Programs().SetExpiryDays(days)
+	return c.State.Programs().SetKeepaliveDays(days)
 }
 
 func (con ArbOwner) SetChainConfig(c ctx, evm mech, serializedChainConfig []byte) error {


### PR DESCRIPTION
Fixes ArbOwner's `SetWasmKeepaliveDays` and adopts wasmer's new unsafe deserialization primitive