### PR TITLE
Fix activation keepalive cost

### DIFF
--- a/arbos/programs/data_pricer.go
+++ b/arbos/programs/data_pricer.go
@@ -68,8 +68,8 @@ func (p *DataPricer) UpdateModel(tempBytes uint32, time uint64) (*big.Int, error
 		return nil, err
 	}
 
-	timeDelta := arbmath.SaturatingUUCast[uint32](time - lastUpdateTime)
-	credit := arbmath.SaturatingUMul(bytesPerSecond, timeDelta)
+	passed := arbmath.SaturatingUUCast[uint32](time - lastUpdateTime)
+	credit := arbmath.SaturatingUMul(bytesPerSecond, passed)
 	demand = arbmath.SaturatingUSub(demand, credit)
 	demand = arbmath.SaturatingUAdd(demand, tempBytes)
 

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -11,10 +11,10 @@ import (
 type ArbWasm struct {
 	Address addr // 0x71
 
-	ProgramActivated             func(ctx, mech, hash, hash, addr, huge, uint16) error
-	ProgramActivatedGasCost      func(hash, hash, addr, huge, uint16) (uint64, error)
-	ProgramLifetimeExtended      func(ctx, mech, hash, huge) error
-	ProgramLifetimeExtendedError func(hash, huge) (uint64, error)
+	ProgramActivated               func(ctx, mech, hash, hash, addr, huge, uint16) error
+	ProgramActivatedGasCost        func(hash, hash, addr, huge, uint16) (uint64, error)
+	ProgramLifetimeExtended        func(ctx, mech, hash, huge) error
+	ProgramLifetimeExtendedGasCost func(hash, huge) (uint64, error)
 
 	ProgramNotActivatedError      func() error
 	ProgramNeedsUpgradeError      func(version, stylusVersion uint16) error

--- a/precompiles/ArbWasm.go
+++ b/precompiles/ArbWasm.go
@@ -11,8 +11,11 @@ import (
 type ArbWasm struct {
 	Address addr // 0x71
 
-	ProgramActivated              func(ctx, mech, hash, hash, addr, huge, uint16) error
-	ProgramActivatedGasCost       func(hash, hash, addr, huge, uint16) (uint64, error)
+	ProgramActivated             func(ctx, mech, hash, hash, addr, huge, uint16) error
+	ProgramActivatedGasCost      func(hash, hash, addr, huge, uint16) (uint64, error)
+	ProgramLifetimeExtended      func(ctx, mech, hash, huge) error
+	ProgramLifetimeExtendedError func(hash, huge) (uint64, error)
+
 	ProgramNotActivatedError      func() error
 	ProgramNeedsUpgradeError      func(version, stylusVersion uint16) error
 	ProgramExpiredError           func(age uint64) error
@@ -40,6 +43,18 @@ func (con ArbWasm) ActivateProgram(c ctx, evm mech, value huge, program addr) (u
 		return version, dataFee, err
 	}
 	return version, dataFee, con.ProgramActivated(c, evm, codeHash, moduleHash, program, dataFee, version)
+}
+
+// Extends a program's expiration date (reverts if too soon)
+func (con ArbWasm) CodehashKeepalive(c ctx, evm mech, value huge, codehash bytes32) error {
+	dataFee, err := c.State.Programs().ProgramKeepalive(codehash, evm.Context.Time)
+	if err != nil {
+		return err
+	}
+	if err := con.payActivationDataFee(c, evm, value, dataFee); err != nil {
+		return err
+	}
+	return con.ProgramLifetimeExtended(c, evm, codehash, dataFee)
 }
 
 // Pays the data component of activation costs
@@ -101,15 +116,6 @@ func (con ArbWasm) PageLimit(c ctx, _ mech) (uint16, error) {
 // Gets the stylus version that program with codehash was most recently compiled with
 func (con ArbWasm) CodehashVersion(c ctx, evm mech, codehash bytes32) (uint16, error) {
 	return c.State.Programs().CodehashVersion(codehash, evm.Context.Time)
-}
-
-// Extends a program's expiration date (reverts if too soon)
-func (con ArbWasm) CodehashKeepalive(c ctx, evm mech, value huge, codehash bytes32) error {
-	dataFee, err := c.State.Programs().ProgramKeepalive(codehash, evm.Context.Time)
-	if err != nil {
-		return err
-	}
-	return con.payActivationDataFee(c, evm, value, dataFee)
 }
 
 // Gets the stylus version that program at addr was most recently compiled with

--- a/util/arbmath/math.go
+++ b/util/arbmath/math.go
@@ -367,6 +367,14 @@ func SaturatingNeg[T Signed](value T) T {
 	return -value
 }
 
+// Integer division but rounding up
+func DivCeil[T Unsigned](value, divisor T) T {
+	if value%divisor == 0 {
+		return value / divisor
+	}
+	return value/divisor + 1
+}
+
 // ApproxExpBasisPoints return the Maclaurin series approximation of e^x, where x is denominated in basis points.
 // The quartic polynomial will underestimate e^x by about 5% as x approaches 20000 bips.
 func ApproxExpBasisPoints(value Bips, degree uint64) Bips {


### PR DESCRIPTION
This PR corrects an issue where program keepalive would charge an incorrect amount due to charging for kilobytes as if they were bytes.

Associated PRs
- https://github.com/OffchainLabs/stylus-contracts/pull/29
- https://github.com/OffchainLabs/stylus-contracts/pull/30