### PR TITLE
Early-exit Host I/O

### DIFF
--- a/arbitrator/stylus/src/env.rs
+++ b/arbitrator/stylus/src/env.rs
@@ -212,10 +212,12 @@ pub enum Escape {
     Memory(MemoryAccessError),
     #[error("internal error: `{0}`")]
     Internal(ErrReport),
-    #[error("Logic error: `{0}`")]
+    #[error("logic error: `{0}`")]
     Logical(ErrReport),
     #[error("out of ink")]
     OutOfInk,
+    #[error("exit early: `{0}`")]
+    Exit(u32),
 }
 
 impl Escape {

--- a/arbitrator/stylus/src/host.rs
+++ b/arbitrator/stylus/src/host.rs
@@ -110,6 +110,14 @@ pub(crate) fn write_result<D: DataReader, E: EvmApi<D>>(
     hostio!(env, write_result(ptr, len))
 }
 
+pub(crate) fn exit_early<D: DataReader, E: EvmApi<D>>(
+    mut env: WasmEnvMut<D, E>,
+    status: u32,
+) -> MaybeEscape {
+    hostio!(env, exit_early(status))?;
+    Err(Escape::Exit(status))
+}
+
 pub(crate) fn storage_load_bytes32<D: DataReader, E: EvmApi<D>>(
     mut env: WasmEnvMut<D, E>,
     key: GuestPtr,

--- a/arbitrator/stylus/src/native.rs
+++ b/arbitrator/stylus/src/native.rs
@@ -128,6 +128,7 @@ impl<D: DataReader, E: EvmApi<D>> NativeInstance<D, E> {
             "vm_hooks" => {
                 "read_args" => func!(host::read_args),
                 "write_result" => func!(host::write_result),
+                "exit_early" => func!(host::exit_early),
                 "storage_load_bytes32" => func!(host::storage_load_bytes32),
                 "storage_store_bytes32" => func!(host::storage_store_bytes32),
                 "call_contract" => func!(host::call_contract),
@@ -336,6 +337,7 @@ pub fn module(wasm: &[u8], compile: CompileConfig) -> Result<Vec<u8>> {
         "vm_hooks" => {
             "read_args" => stub!(|_: u32|),
             "write_result" => stub!(|_: u32, _: u32|),
+            "exit_early" => stub!(|_: u32|),
             "storage_load_bytes32" => stub!(|_: u32, _: u32|),
             "storage_store_bytes32" => stub!(|_: u32, _: u32|),
             "call_contract" => stub!(u8 <- |_: u32, _: u32, _: u32, _: u32, _: u64, _: u32|),

--- a/arbitrator/stylus/src/run.rs
+++ b/arbitrator/stylus/src/run.rs
@@ -99,11 +99,12 @@ impl<D: DataReader, E: EvmApi<D>> RunProgram for NativeInstance<D, E> {
                     Ok(escape) => escape,
                     Err(error) => return Ok(Failure(eyre!(error).wrap_err("hard user error"))),
                 };
-                return Ok(match escape {
-                    Escape::OutOfInk => OutOfInk,
-                    Escape::Memory(error) => UserOutcome::Failure(error.into()),
-                    Escape::Internal(error) | Escape::Logical(error) => UserOutcome::Failure(error),
-                });
+                match escape {
+                    Escape::OutOfInk => return Ok(OutOfInk),
+                    Escape::Memory(error) => return Ok(Failure(error.into())),
+                    Escape::Internal(error) | Escape::Logical(error) => return Ok(Failure(error)),
+                    Escape::Exit(status) => status,
+                }
             }
         };
 

--- a/arbitrator/stylus/src/test/native.rs
+++ b/arbitrator/stylus/src/test/native.rs
@@ -466,18 +466,18 @@ fn test_exit_early() -> Result<()> {
     // in panic-after-write.wat
     //     the program writes a result but then panics
 
+    let file = |f: &str| format!("tests/exit-early/{f}.wat");
     let (compile, config, ink) = test_configs();
-    std::env::set_current_dir("tests/exit-early")?;
     let args = &[0x01; 32];
 
-    let mut native = TestInstance::new_linked("exit-early.wat", &compile, config)?;
+    let mut native = TestInstance::new_linked(file("exit-early"), &compile, config)?;
     let output = match native.run_main(args, config, ink)? {
         UserOutcome::Revert(output) => output,
         err => bail!("expected revert: {}", err.red()),
     };
     assert_eq!(hex::encode(output), hex::encode(args));
 
-    let mut native = TestInstance::new_linked("panic-after-write.wat", &compile, config)?;
+    let mut native = TestInstance::new_linked(file("panic-after-write"), &compile, config)?;
     match native.run_main(args, config, ink)? {
         UserOutcome::Failure(error) => println!("{error:?}"),
         err => bail!("expected hard error: {}", err.red()),

--- a/arbitrator/stylus/tests/evm-data/src/main.rs
+++ b/arbitrator/stylus/tests/evm-data/src/main.rs
@@ -4,7 +4,6 @@
 #![no_main]
 
 extern crate alloc;
-use alloc::vec::Vec;
 
 use stylus_sdk::{
     alloy_primitives::{Address, B256, U256},

--- a/arbitrator/stylus/tests/evm-data/src/main.rs
+++ b/arbitrator/stylus/tests/evm-data/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2023, Offchain Labs, Inc.
+// Copyright 2023-2024, Offchain Labs, Inc.
 // For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
 
 #![no_main]

--- a/arbitrator/stylus/tests/exit-early/exit-early.wat
+++ b/arbitrator/stylus/tests/exit-early/exit-early.wat
@@ -1,0 +1,24 @@
+;; Copyright 2024, Offchain Labs, Inc.
+;; For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+(module
+    (import "vm_hooks" "read_args"    (func $read_args    (param i32)))
+    (import "vm_hooks" "write_result" (func $write_result (param i32 i32)))
+    (import "vm_hooks" "exit_early"   (func $exit         (param i32)))
+    (memory (export "memory") 1 1)
+    (func (export "user_entrypoint") (param $args_len i32) (result i32)
+        ;; write args to offset 0
+        (call $read_args (i32.const 0))
+
+        ;; set the args as the result
+        (call $write_result (i32.const 0) (local.get $args_len))
+
+        ;; exit with the status code given by the first byte
+        i32.const 0
+        i32.load8_u
+        call $exit
+
+        ;; unreachable
+        (i32.const 0xff)
+    )
+)

--- a/arbitrator/stylus/tests/exit-early/panic-after-write.wat
+++ b/arbitrator/stylus/tests/exit-early/panic-after-write.wat
@@ -1,0 +1,19 @@
+;; Copyright 2024, Offchain Labs, Inc.
+;; For license information, see https://github.com/OffchainLabs/nitro/blob/master/LICENSE
+
+(module
+    (import "vm_hooks" "read_args"    (func $read_args    (param i32)))
+    (import "vm_hooks" "write_result" (func $write_result (param i32 i32)))
+    (import "vm_hooks" "exit_early"   (func $exit         (param i32)))
+    (memory (export "memory") 1 1)
+    (func (export "user_entrypoint") (param $args_len i32) (result i32)
+        ;; write args to offset 0
+        (call $read_args (i32.const 0))
+
+        ;; set the args as the result
+        (call $write_result (i32.const 0) (local.get $args_len))
+
+        ;; perform a hard revert (results should be discarded)
+        unreachable
+    )
+)

--- a/arbitrator/wasm-libraries/forward/src/main.rs
+++ b/arbitrator/wasm-libraries/forward/src/main.rs
@@ -6,9 +6,10 @@ use std::{fs::File, io::Write, path::PathBuf};
 use structopt::StructOpt;
 
 /// order matters!
-const HOSTIOS: [[&str; 3]; 33] = [
+const HOSTIOS: [[&str; 3]; 34] = [
     ["read_args", "i32", ""],
     ["write_result", "i32 i32", ""],
+    ["exit_early", "i32", ""],
     ["storage_load_bytes32", "i32 i32", ""],
     ["storage_store_bytes32", "i32 i32", ""],
     ["call_contract", "i32 i32 i32 i32 i64 i32", "i32"],

--- a/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
+++ b/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
@@ -114,7 +114,7 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         trace!("write_result", self, &*self.outs(), &[])
     }
 
-    /// Exists program execution early with the given status code.
+    /// Exits program execution early with the given status code.
     /// If `0`, the program returns successfully with any data supplied by `write_result`.
     /// Otherwise, the program reverts and treats any `write_result` data as revert data.
     ///

--- a/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
+++ b/arbitrator/wasm-libraries/user-host-trait/src/lib.rs
@@ -114,6 +114,19 @@ pub trait UserHost<DR: DataReader>: GasMeteredMachine {
         trace!("write_result", self, &*self.outs(), &[])
     }
 
+    /// Exists program execution early with the given status code.
+    /// If `0`, the program returns successfully with any data supplied by `write_result`.
+    /// Otherwise, the program reverts and treats any `write_result` data as revert data.
+    ///
+    /// The semantics are equivalent to that of the EVM's [`Return`] and [`Revert`] opcodes.
+    /// Note: this function just traces, it's up to the caller to actually perform the exit.
+    ///
+    /// [`Return`]: https://www.evm.codes/#f3
+    /// [`Revert`]: https://www.evm.codes/#fd
+    fn exit_early(&mut self, status: u32) -> Result<(), Self::Err> {
+        trace!("exit_early", self, be!(status), &[])
+    }
+
     /// Reads a 32-byte value from permanent storage. Stylus's storage format is identical to
     /// that of the EVM. This means that, under the hood, this hostio is accessing the 32-byte
     /// value stored in the EVM state trie at offset `key`, which will be `0` when not previously

--- a/arbitrator/wasm-libraries/user-host/src/host.rs
+++ b/arbitrator/wasm-libraries/user-host/src/host.rs
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn user_host__read_args(ptr: GuestPtr) {
 #[no_mangle]
 pub unsafe extern "C" fn user_host__exit_early(status: u32) {
     hostio!(exit_early(status));
-    Program::current().exited_early = Some(match status {
+    Program::current().early_exit = Some(match status {
         0 => UserOutcomeKind::Success,
         _ => UserOutcomeKind::Revert,
     });

--- a/arbitrator/wasm-libraries/user-host/src/host.rs
+++ b/arbitrator/wasm-libraries/user-host/src/host.rs
@@ -2,6 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 
 use crate::program::Program;
+use arbutil::evm::user::UserOutcomeKind;
 use caller_env::GuestPtr;
 use user_host_trait::UserHost;
 
@@ -25,6 +26,16 @@ macro_rules! hostio {
 #[no_mangle]
 pub unsafe extern "C" fn user_host__read_args(ptr: GuestPtr) {
     hostio!(read_args(ptr))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn user_host__exit_early(status: u32) {
+    hostio!(exit_early(status));
+    Program::current().exited_early = Some(match status {
+        0 => UserOutcomeKind::Success,
+        _ => UserOutcomeKind::Revert,
+    });
+    set_trap();
 }
 
 #[no_mangle]

--- a/arbitrator/wasm-libraries/user-host/src/link.rs
+++ b/arbitrator/wasm-libraries/user-host/src/link.rs
@@ -193,7 +193,6 @@ pub unsafe extern "C" fn program_internal__set_done(mut status: UserOutcomeKind)
     let program = Program::current();
     let module = program.module;
     let mut outs = program.outs.as_slice();
-
     let mut ink_left = program_ink_left(module);
 
     // apply any early exit codes

--- a/arbitrator/wasm-libraries/user-host/src/link.rs
+++ b/arbitrator/wasm-libraries/user-host/src/link.rs
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn program_internal__set_done(mut status: UserOutcomeKind)
     let mut ink_left = program_ink_left(module);
 
     // apply any early exit codes
-    if let Some(early) = program.exited_early {
+    if let Some(early) = program.early_exit {
         status = early;
     }
 

--- a/arbitrator/wasm-libraries/user-host/src/link.rs
+++ b/arbitrator/wasm-libraries/user-host/src/link.rs
@@ -187,26 +187,32 @@ pub unsafe extern "C" fn program_internal__args_len(module: u32) -> usize {
 /// used by program-exec
 /// sets status of the last program and sends a program_done request
 #[no_mangle]
-pub unsafe extern "C" fn program_internal__set_done(mut status: u8) -> u32 {
+pub unsafe extern "C" fn program_internal__set_done(mut status: UserOutcomeKind) -> u32 {
+    use UserOutcomeKind::*;
+
     let program = Program::current();
     let module = program.module;
-    let mut outs = &program.outs;
+    let mut outs = program.outs.as_slice();
 
     let mut ink_left = program_ink_left(module);
 
-    let empty_vec = vec![];
+    // apply any early exit codes
+    if let Some(early) = program.exited_early {
+        status = early;
+    }
+
     // check if instrumentation stopped the program
-    use UserOutcomeKind::*;
     if program_ink_status(module) != 0 {
-        status = OutOfInk.into();
-        outs = &empty_vec;
+        status = OutOfInk;
+        outs = &[];
         ink_left = 0;
     }
     if program_stack_left(module) == 0 {
-        status = OutOfStack.into();
-        outs = &empty_vec;
+        status = OutOfStack;
+        outs = &[];
         ink_left = 0;
     }
+
     let gas_left = program.config.pricing.ink_to_gas(ink_left);
 
     let mut output = Vec::with_capacity(8 + outs.len());

--- a/arbitrator/wasm-libraries/user-host/src/program.rs
+++ b/arbitrator/wasm-libraries/user-host/src/program.rs
@@ -5,6 +5,7 @@ use arbutil::{
     evm::{
         api::{EvmApiMethod, VecReader, EVM_API_METHOD_REQ_OFFSET},
         req::{EvmApiRequestor, RequestHandler},
+        user::UserOutcomeKind,
         EvmData,
     },
     Color,
@@ -78,6 +79,8 @@ pub(crate) struct Program {
     pub module: u32,
     /// Call configuration.
     pub config: StylusConfig,
+    /// Whether the program exited early
+    pub exited_early: Option<UserOutcomeKind>,
 }
 
 #[link(wasm_import_module = "hostio")]
@@ -166,6 +169,7 @@ impl Program {
             evm_data,
             module,
             config,
+            exited_early: None,
         };
         unsafe { PROGRAMS.push(Box::new(program)) }
     }

--- a/arbitrator/wasm-libraries/user-host/src/program.rs
+++ b/arbitrator/wasm-libraries/user-host/src/program.rs
@@ -79,8 +79,8 @@ pub(crate) struct Program {
     pub module: u32,
     /// Call configuration.
     pub config: StylusConfig,
-    /// Whether the program exited early
-    pub exited_early: Option<UserOutcomeKind>,
+    /// Whether the program exited early.
+    pub early_exit: Option<UserOutcomeKind>,
 }
 
 #[link(wasm_import_module = "hostio")]
@@ -169,7 +169,7 @@ impl Program {
             evm_data,
             module,
             config,
-            exited_early: None,
+            early_exit: None,
         };
         unsafe { PROGRAMS.push(Box::new(program)) }
     }

--- a/system_tests/program_test.go
+++ b/system_tests/program_test.go
@@ -1067,12 +1067,11 @@ func testEarlyExit(t *testing.T, jit bool) {
 	earlyAddress := deployWasm(t, ctx, auth, l2client, "../arbitrator/stylus/tests/exit-early/exit-early.wat")
 	panicAddress := deployWasm(t, ctx, auth, l2client, "../arbitrator/stylus/tests/exit-early/panic-after-write.wat")
 
-	ensure := func(tx *types.Transaction, err error) *types.Receipt {
+	ensure := func(tx *types.Transaction, err error) {
 		t.Helper()
 		Require(t, err)
-		receipt, err := EnsureTxSucceeded(ctx, l2client, tx)
+		_, err = EnsureTxSucceeded(ctx, l2client, tx)
 		Require(t, err)
-		return receipt
 	}
 
 	_, tx, mock, err := mocksgen.DeployProgramTest(&auth, l2client)

--- a/system_tests/stylus_test.go
+++ b/system_tests/stylus_test.go
@@ -55,3 +55,7 @@ func TestProgramArbitratorActivateFails(t *testing.T) {
 	t.Parallel()
 	testActivateFails(t, false)
 }
+
+func TestProgramArbitratorEarlyExit(t *testing.T) {
+	testEarlyExit(t, false)
+}


### PR DESCRIPTION
Adds an `exit_early` Host I/O to suspend execution without returning from the entrypoint.

The mechanism allows user programs to revert (or succeed) with data, which differentiates this feature from just inducing a hard error.

Resolves STY-29