### PR TITLE
Compress Validator Modules

### DIFF
--- a/arbitrator/brotli/src/dicts/mod.rs
+++ b/arbitrator/brotli/src/dicts/mod.rs
@@ -75,3 +75,17 @@ impl Dictionary {
         }
     }
 }
+
+impl From<Dictionary> for u8 {
+    fn from(value: Dictionary) -> Self {
+        value as u32 as u8
+    }
+}
+
+impl TryFrom<u8> for Dictionary {
+    type Error = <Dictionary as TryFrom<u32>>::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        (value as u32).try_into()
+    }
+}

--- a/arbitrator/brotli/src/lib.rs
+++ b/arbitrator/brotli/src/lib.rs
@@ -114,8 +114,20 @@ pub fn compress(
     window_size: u32,
     dictionary: Dictionary,
 ) -> Result<Vec<u8>, BrotliStatus> {
+    compress_into(input, Vec::new(), level, window_size, dictionary)
+}
+
+/// Brotli compresses a slice, extending the `output` specified.
+pub fn compress_into(
+    input: &[u8],
+    mut output: Vec<u8>,
+    level: u32,
+    window_size: u32,
+    dictionary: Dictionary,
+) -> Result<Vec<u8>, BrotliStatus> {
     let max_size = compression_bound(input.len(), level);
-    let mut output = Vec::with_capacity(max_size);
+    let needed = max_size.saturating_sub(output.spare_capacity_mut().len());
+    output.reserve(needed);
     unsafe {
         let state = BrotliEncoderCreateInstance(None, None, ptr::null_mut());
 

--- a/arbitrator/brotli/src/lib.rs
+++ b/arbitrator/brotli/src/lib.rs
@@ -126,7 +126,7 @@ pub fn compress_into(
     dictionary: Dictionary,
 ) -> Result<Vec<u8>, BrotliStatus> {
     let max_size = compression_bound(input.len(), level);
-    let needed = max_size.saturating_sub(output.spare_capacity_mut().len());
+    let needed = max_size.saturating_sub(output.capacity() - output.len());
     output.reserve_exact(needed);
 
     let space = output.spare_capacity_mut();

--- a/arbitrator/prover/src/machine.rs
+++ b/arbitrator/prover/src/machine.rs
@@ -627,16 +627,27 @@ impl Module {
         data
     }
 
+    /// Serializes the `Module` into bytes that can be stored in the db.
+    /// The format employed is forward-compatible with future brotli dictionary and caching policies.
     pub fn into_bytes(&self) -> Vec<u8> {
         let data = bincode::serialize(self).unwrap();
-        let header = vec![Dictionary::Empty.into()];
+        let header = vec![1 + Into::<u8>::into(Dictionary::Empty)];
         brotli::compress_into(&data, header, 0, 22, Dictionary::Empty).expect("failed to compress")
     }
 
-    pub unsafe fn from_bytes(bytes: &[u8]) -> Self {
-        let dict = Dictionary::try_from(bytes[0]).expect("unknown dictionary");
-        let data = brotli::decompress(&bytes[1..], dict).expect("failed to decompress");
-        bincode::deserialize(&data).unwrap()
+    /// Deserializes a `Module` from db bytes.
+    ///
+    /// # Safety
+    ///
+    /// The bytes must have been produced by `into_bytes` and represent a valid `Module`.
+    pub unsafe fn from_bytes(data: &[u8]) -> Self {
+        if data[0] > 0 {
+            let dict = Dictionary::try_from(data[0] - 1).expect("unknown dictionary");
+            let data = brotli::decompress(&data[1..], dict).expect("failed to inflate");
+            bincode::deserialize(&data).unwrap()
+        } else {
+            bincode::deserialize(&data[1..]).unwrap()
+        }
     }
 }
 


### PR DESCRIPTION
Compresses validator modules in the db, saving space. The mechanism used relies on a 1-byte header which can be used to select different dictionaries, or even forgo compression altogether.

Resolves STY-14
