### PR TITLE
Diffuse Dencun `SELF_DESTRUCT` 

### DIFF
--- a/arbos/programs/programs.go
+++ b/arbos/programs/programs.go
@@ -76,6 +76,10 @@ func (p Programs) ActivateProgram(evm *vm.EVM, address common.Address, debugMode
 	burner := p.programs.Burner()
 	time := evm.Context.Time
 
+	if statedb.HasSelfDestructed(address) {
+		return 0, codeHash, common.Hash{}, nil, false, errors.New("self destructed")
+	}
+
 	params, err := p.Params()
 	if err != nil {
 		return 0, codeHash, common.Hash{}, nil, false, err


### PR DESCRIPTION
The latest Nitro merge pulls in suport for Dencun, which has new `SELF_DESTRUCT` semantics. This PR hardens Stylus against `SELF_DESTRUCT` by disabling it during activation and during delegate calls into EVM code.

Resolves STY-79
- https://github.com/OffchainLabs/stylus-geth/pull/35