### PR TITLE
Add Stylus to ArbOS 30

### DIFF
--- a/arbos/arbosState/arbosstate.go
+++ b/arbos/arbosState/arbosstate.go
@@ -164,11 +164,6 @@ var (
 
 var PrecompileMinArbOSVersions = make(map[common.Address]uint64)
 
-type arbPrecompile struct {
-	address      common.Address
-	arbosVersion uint64
-}
-
 func InitializeArbosState(stateDB vm.StateDB, burner burn.Burner, chainConfig *params.ChainConfig, initMessage *arbostypes.ParsedInitMessage) (*ArbosState, error) {
 	sto := storage.NewGeth(stateDB, burner)
 	arbosVersion, err := sto.GetUint64ByUint64(uint64(versionOffset))

--- a/arbos/arbostypes/incomingmessage.go
+++ b/arbos/arbostypes/incomingmessage.go
@@ -34,9 +34,6 @@ const (
 
 const MaxL2MessageSize = 256 * 1024
 
-const ArbosVersion_FixRedeemGas = uint64(11)
-const ArbosVersion_Stylus = uint64(30)
-
 type L1IncomingMessageHeader struct {
 	Kind        uint8          `json:"kind"`
 	Poster      common.Address `json:"sender"`

--- a/arbos/arbostypes/incomingmessage.go
+++ b/arbos/arbostypes/incomingmessage.go
@@ -35,7 +35,7 @@ const (
 const MaxL2MessageSize = 256 * 1024
 
 const ArbosVersion_FixRedeemGas = uint64(11)
-const ArbosVersion_Stylus = uint64(20)
+const ArbosVersion_Stylus = uint64(30)
 
 type L1IncomingMessageHeader struct {
 	Kind        uint8          `json:"kind"`

--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -398,7 +398,7 @@ func ProduceBlockAdvanced(
 		txGasUsed := header.GasUsed - preTxHeaderGasUsed
 
 		arbosVer := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
-		if arbosVer >= arbostypes.ArbosVersion_FixRedeemGas {
+		if arbosVer >= types.ArbosVersion_FixRedeemGas {
 			// subtract gas burned for future use
 			for _, scheduledTx := range result.ScheduledTxes {
 				switch inner := scheduledTx.GetInner().(type) {

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -630,6 +630,11 @@ func Precompiles() map[addr]ArbosPrecompile {
 	arbos.InternalTxStartBlockMethodID = ArbosActs.GetMethodID("StartBlock")
 	arbos.InternalTxBatchPostingReportMethodID = ArbosActs.GetMethodID("BatchPostingReport")
 
+	for _, contract := range contracts {
+		precompile := contract.Precompile()
+		arbosState.PrecompileMinArbOSVersions[precompile.address] = precompile.arbosVersion
+	}
+
 	return contracts
 }
 

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/arbos/arbosState"
-	"github.com/offchainlabs/nitro/arbos/arbostypes"
 	"github.com/offchainlabs/nitro/arbos/programs"
 	"github.com/offchainlabs/nitro/arbos/util"
 	pgen "github.com/offchainlabs/nitro/solgen/go/precompilesgen"
@@ -559,7 +558,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 
 	ArbWasmImpl := &ArbWasm{Address: types.ArbWasmAddress}
 	ArbWasm := insert(MakePrecompile(pgen.ArbWasmMetaData, ArbWasmImpl))
-	ArbWasm.arbosVersion = arbostypes.ArbosVersion_Stylus
+	ArbWasm.arbosVersion = types.ArbosVersion_Stylus
 	programs.ProgramNotWasmError = ArbWasmImpl.ProgramNotWasmError
 	programs.ProgramNotActivatedError = ArbWasmImpl.ProgramNotActivatedError
 	programs.ProgramNeedsUpgradeError = ArbWasmImpl.ProgramNeedsUpgradeError
@@ -572,7 +571,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 
 	ArbWasmCacheImpl := &ArbWasmCache{Address: types.ArbWasmCacheAddress}
 	ArbWasmCache := insert(MakePrecompile(pgen.ArbWasmCacheMetaData, ArbWasmCacheImpl))
-	ArbWasmCache.arbosVersion = arbostypes.ArbosVersion_Stylus
+	ArbWasmCache.arbosVersion = types.ArbosVersion_Stylus
 	for _, method := range ArbWasmCache.methods {
 		method.arbosVersion = ArbWasmCache.arbosVersion
 	}
@@ -618,12 +617,12 @@ func Precompiles() map[addr]ArbosPrecompile {
 		"SetWasmBlockCacheSize", "AddWasmCacheManager", "RemoveWasmCacheManager",
 	}
 	for _, method := range stylusMethods {
-		ArbOwner.methodsByName[method].arbosVersion = arbostypes.ArbosVersion_Stylus
+		ArbOwner.methodsByName[method].arbosVersion = types.ArbosVersion_Stylus
 	}
 
 	insert(ownerOnly(ArbOwnerImpl.Address, ArbOwner, emitOwnerActs))
 	_, arbDebug := MakePrecompile(pgen.ArbDebugMetaData, &ArbDebug{Address: types.ArbDebugAddress})
-	arbDebug.methodsByName["Panic"].arbosVersion = arbostypes.ArbosVersion_Stylus
+	arbDebug.methodsByName["Panic"].arbosVersion = types.ArbosVersion_Stylus
 	insert(debugOnly(arbDebug.address, arbDebug))
 
 	ArbosActs := insert(MakePrecompile(pgen.ArbosActsMetaData, &ArbosActs{Address: types.ArbosAddress}))

--- a/precompiles/precompile_test.go
+++ b/precompiles/precompile_test.go
@@ -190,8 +190,8 @@ func TestPrecompilesPerArbosVersion(t *testing.T) {
 		5:  3,
 		10: 2,
 		11: 4,
-		20: 8 + 37, // 37 for stylus
-		// TODO: move stylus methods to ArbOS 30
+		20: 8,
+		30: 37,
 	}
 
 	precompiles := Precompiles()


### PR DESCRIPTION
This PR adds Stylus to ArbOS 30.

Included are changes to trigger installing the new precompiles during the upgrade. Importantly, this means delaying the `SetCode` operation until the time of the upgrade, for which I went ahead and did a small refactor.

Resolves STY-99
- https://github.com/OffchainLabs/stylus-geth/pull/39
- https://github.com/OffchainLabs/stylus-geth/pull/40