### PR TITLE
Split Nitro and Stylus Precompile Contracts

### DIFF
--- a/arbos/block_processor.go
+++ b/arbos/block_processor.go
@@ -398,7 +398,7 @@ func ProduceBlockAdvanced(
 		txGasUsed := header.GasUsed - preTxHeaderGasUsed
 
 		arbosVer := types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion
-		if arbosVer >= types.ArbosVersion_FixRedeemGas {
+		if arbosVer >= params.ArbosVersion_FixRedeemGas {
 			// subtract gas burned for future use
 			for _, scheduledTx := range result.ScheduledTxes {
 				switch inner := scheduledTx.GetInner().(type) {

--- a/gethhook/geth-hook.go
+++ b/gethhook/geth-hook.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/offchainlabs/nitro/arbos"
 	"github.com/offchainlabs/nitro/precompiles"
 )
@@ -51,8 +52,13 @@ func init() {
 	}
 
 	for k, v := range vm.PrecompiledContractsBerlin {
-		vm.PrecompiledAddressesArbitrum = append(vm.PrecompiledAddressesArbitrum, k)
-		vm.PrecompiledContractsArbitrum[k] = v
+		vm.PrecompiledAddressesArbitrumNitro = append(vm.PrecompiledAddressesArbitrumNitro, k)
+		vm.PrecompiledContractsArbitrumNitro[k] = v
+	}
+
+	for k, v := range vm.PrecompiledContractsCancun {
+		vm.PrecompiledAddressesArbitrumStylus = append(vm.PrecompiledAddressesArbitrumStylus, k)
+		vm.PrecompiledContractsArbitrumStylus[k] = v
 	}
 
 	precompileErrors := make(map[[4]byte]abi.Error)
@@ -63,8 +69,13 @@ func init() {
 			precompileErrors[id] = errABI
 		}
 		var wrapped vm.AdvancedPrecompile = ArbosPrecompileWrapper{precompile}
-		vm.PrecompiledContractsArbitrum[addr] = wrapped
-		vm.PrecompiledAddressesArbitrum = append(vm.PrecompiledAddressesArbitrum, addr)
+		vm.PrecompiledContractsArbitrumStylus[addr] = wrapped
+		vm.PrecompiledAddressesArbitrumStylus = append(vm.PrecompiledAddressesArbitrumStylus, addr)
+
+		if precompile.Precompile().ArbosVersion() < params.ArbosVersion_Stylus {
+			vm.PrecompiledContractsArbitrumNitro[addr] = wrapped
+			vm.PrecompiledAddressesArbitrumNitro = append(vm.PrecompiledAddressesArbitrumNitro, addr)
+		}
 	}
 
 	core.RenderRPCError = func(data []byte) error {

--- a/precompiles/precompile.go
+++ b/precompiles/precompile.go
@@ -558,7 +558,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 
 	ArbWasmImpl := &ArbWasm{Address: types.ArbWasmAddress}
 	ArbWasm := insert(MakePrecompile(pgen.ArbWasmMetaData, ArbWasmImpl))
-	ArbWasm.arbosVersion = types.ArbosVersion_Stylus
+	ArbWasm.arbosVersion = params.ArbosVersion_Stylus
 	programs.ProgramNotWasmError = ArbWasmImpl.ProgramNotWasmError
 	programs.ProgramNotActivatedError = ArbWasmImpl.ProgramNotActivatedError
 	programs.ProgramNeedsUpgradeError = ArbWasmImpl.ProgramNeedsUpgradeError
@@ -571,7 +571,7 @@ func Precompiles() map[addr]ArbosPrecompile {
 
 	ArbWasmCacheImpl := &ArbWasmCache{Address: types.ArbWasmCacheAddress}
 	ArbWasmCache := insert(MakePrecompile(pgen.ArbWasmCacheMetaData, ArbWasmCacheImpl))
-	ArbWasmCache.arbosVersion = types.ArbosVersion_Stylus
+	ArbWasmCache.arbosVersion = params.ArbosVersion_Stylus
 	for _, method := range ArbWasmCache.methods {
 		method.arbosVersion = ArbWasmCache.arbosVersion
 	}
@@ -617,12 +617,12 @@ func Precompiles() map[addr]ArbosPrecompile {
 		"SetWasmBlockCacheSize", "AddWasmCacheManager", "RemoveWasmCacheManager",
 	}
 	for _, method := range stylusMethods {
-		ArbOwner.methodsByName[method].arbosVersion = types.ArbosVersion_Stylus
+		ArbOwner.methodsByName[method].arbosVersion = params.ArbosVersion_Stylus
 	}
 
 	insert(ownerOnly(ArbOwnerImpl.Address, ArbOwner, emitOwnerActs))
 	_, arbDebug := MakePrecompile(pgen.ArbDebugMetaData, &ArbDebug{Address: types.ArbDebugAddress})
-	arbDebug.methodsByName["Panic"].arbosVersion = types.ArbosVersion_Stylus
+	arbDebug.methodsByName["Panic"].arbosVersion = params.ArbosVersion_Stylus
 	insert(debugOnly(arbDebug.address, arbDebug))
 
 	ArbosActs := insert(MakePrecompile(pgen.ArbosActsMetaData, &ArbosActs{Address: types.ArbosAddress}))
@@ -649,6 +649,10 @@ func (p *Precompile) GetMethodID(name string) bytes4 {
 		panic(fmt.Sprintf("Precompile %v does not have a method with the name %v", p.name, name))
 	}
 	return *(*bytes4)(method.template.ID)
+}
+
+func (p *Precompile) ArbosVersion() uint64 {
+	return p.arbosVersion
 }
 
 // Call a precompile in typed form, deserializing its inputs and serializing its outputs


### PR DESCRIPTION
Separates out Nitro and Stylus Precompile contract lists, and includes the left-out Dencun precompile for ArbOS 30

Associated PRs
- https://github.com/OffchainLabs/stylus-geth/pull/41